### PR TITLE
Add spotless plugin to gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.junit.platform:junit-platform-gradle-plugin:1.1.0-M1'
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:3.8.0"
     }
 }
 
@@ -15,6 +16,7 @@ repositories {
 apply plugin: 'java-library'
 apply plugin: 'jacoco'
 apply plugin: 'org.junit.platform.gradle.plugin'
+apply plugin: 'com.diffplug.gradle.spotless'
 
 sourceCompatibility = 1.8
 
@@ -58,5 +60,11 @@ jacocoTestReport {
 junitPlatformTest {
     jacoco {
         destinationFile = file("$buildDir/jacoco/test.exec")
+    }
+}
+
+spotless {
+    java {
+        eclipse().configFile 'ocelot-wars-code-conventions.xml'	// XML file dumped out by the Eclipse formatter
     }
 }

--- a/ocelot-wars-code-conventions.xml
+++ b/ocelot-wars-code-conventions.xml
@@ -72,7 +72,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="200"/>
 <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>

--- a/src/main/java/com/github/ocelotwars/engine/Asset.java
+++ b/src/main/java/com/github/ocelotwars/engine/Asset.java
@@ -2,14 +2,14 @@ package com.github.ocelotwars.engine;
 
 public abstract class Asset {
 
-	private Player owner;
+    private Player owner;
 
-	public Asset(Player owner) {
+    public Asset(Player owner) {
         this.owner = owner;
     }
 
     public Player getOwner() {
         return owner;
     }
-	
+
 }

--- a/src/main/java/com/github/ocelotwars/engine/Command.java
+++ b/src/main/java/com/github/ocelotwars/engine/Command.java
@@ -3,11 +3,11 @@ package com.github.ocelotwars.engine;
 public interface Command {
 
     public static final Command NULL = new Command() {
-    	@Override
-    	public void execute(Playground playground) {
-    	}
+        @Override
+        public void execute(Playground playground) {
+        }
     };
 
-	void execute(Playground playground);
+    void execute(Playground playground);
 
 }

--- a/src/main/java/com/github/ocelotwars/engine/Direction.java
+++ b/src/main/java/com/github/ocelotwars/engine/Direction.java
@@ -1,17 +1,17 @@
 package com.github.ocelotwars.engine;
 
 public enum Direction {
-	NORTH(0, -1), EAST(1, 0), SOUTH(0, 1), WEST(-1, 0);
+    NORTH(0, -1), EAST(1, 0), SOUTH(0, 1), WEST(-1, 0);
 
-	private int deltax;
-	private int deltay;
+    private int deltax;
+    private int deltay;
 
-	private Direction(int deltax, int deltay) {
-		this.deltax = deltax;
-		this.deltay = deltay;
-	}
+    private Direction(int deltax, int deltay) {
+        this.deltax = deltax;
+        this.deltay = deltay;
+    }
 
-	public Position shift(Position position) {
-		return new Position(position.x + deltax, position.y + deltay);
-	}
+    public Position shift(Position position) {
+        return new Position(position.x + deltax, position.y + deltay);
+    }
 }

--- a/src/main/java/com/github/ocelotwars/engine/Headquarter.java
+++ b/src/main/java/com/github/ocelotwars/engine/Headquarter.java
@@ -16,7 +16,7 @@ public class Headquarter extends Asset {
     public void setTile(Tile tile) {
         this.tile = tile;
     }
-    
+
     public Tile getTile() {
         return tile;
     }

--- a/src/main/java/com/github/ocelotwars/engine/NoSuchAssetException.java
+++ b/src/main/java/com/github/ocelotwars/engine/NoSuchAssetException.java
@@ -2,18 +2,18 @@ package com.github.ocelotwars.engine;
 
 public class NoSuchAssetException extends RuntimeException {
 
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	private NoSuchAssetException(String message) {
-		super(message);
-	}
+    private NoSuchAssetException(String message) {
+        super(message);
+    }
 
-	public static NoSuchAssetException forUnit(int unitId) {
-		return new NoSuchAssetException("Unit " + unitId + " not found.");
-	}
+    public static NoSuchAssetException forUnit(int unitId) {
+        return new NoSuchAssetException("Unit " + unitId + " not found.");
+    }
 
-	public static NoSuchAssetException forHeadquarter(Player player) {
-		return new NoSuchAssetException("Headquarter for " + player.getName() + " not found.");
-	}
+    public static NoSuchAssetException forHeadquarter(Player player) {
+        return new NoSuchAssetException("Headquarter for " + player.getName() + " not found.");
+    }
 
 }

--- a/src/main/java/com/github/ocelotwars/engine/NotUnitOwnerException.java
+++ b/src/main/java/com/github/ocelotwars/engine/NotUnitOwnerException.java
@@ -2,14 +2,14 @@ package com.github.ocelotwars.engine;
 
 public class NotUnitOwnerException extends RuntimeException {
 
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	private NotUnitOwnerException(String message) {
-		super(message);
-	}
+    private NotUnitOwnerException(String message) {
+        super(message);
+    }
 
-	public static NotUnitOwnerException forPlayerAndUnit(Player player, int unitId) {
-		return new NotUnitOwnerException("Unit " + unitId + " is not under control of player " + player.getName());
-	}
+    public static NotUnitOwnerException forPlayerAndUnit(Player player, int unitId) {
+        return new NotUnitOwnerException("Unit " + unitId + " is not under control of player " + player.getName());
+    }
 
 }

--- a/src/main/java/com/github/ocelotwars/engine/Player.java
+++ b/src/main/java/com/github/ocelotwars/engine/Player.java
@@ -2,39 +2,39 @@ package com.github.ocelotwars.engine;
 
 public class Player {
 
-	private String name;
+    private String name;
 
-	public Player(String name) {
-		this.name = name;
-	}
+    public Player(String name) {
+        this.name = name;
+    }
 
-	public String getName() {
-		return name;
-	}
+    public String getName() {
+        return name;
+    }
 
-	@Override
-	public int hashCode() {
-		return name.hashCode();
-	}
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null) {
-			return false;
-		}
-		if (getClass() != obj.getClass()) {
-			return false;
-		}
-		Player that = (Player) obj;
-		return this.name.equals(that.name);
-	}
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Player that = (Player) obj;
+        return this.name.equals(that.name);
+    }
 
-	@Override
-	public String toString() {
-		return name;
-	}
-	
+    @Override
+    public String toString() {
+        return name;
+    }
+
 }

--- a/src/main/java/com/github/ocelotwars/engine/Playground.java
+++ b/src/main/java/com/github/ocelotwars/engine/Playground.java
@@ -7,77 +7,77 @@ import java.util.Map;
 
 public class Playground {
 
-	private int width;
-	private int height;
-	private Tile[][] tiles;
-	private Map<Integer, Unit> units;
-	private List<Headquarter> headquarters;
+    private int width;
+    private int height;
+    private Tile[][] tiles;
+    private Map<Integer, Unit> units;
+    private List<Headquarter> headquarters;
 
-	public Playground() {
-		this.units = new HashMap<>();
-		this.headquarters = new ArrayList<>();
-	}
+    public Playground() {
+        this.units = new HashMap<>();
+        this.headquarters = new ArrayList<>();
+    }
 
-	public Playground init(int width, int height) {
-		this.width = width;
-		this.height = height;
-		this.tiles = initTiles(width, height);
-		return this;
-	}
+    public Playground init(int width, int height) {
+        this.width = width;
+        this.height = height;
+        this.tiles = initTiles(width, height);
+        return this;
+    }
 
-	private static Tile[][] initTiles(int width, int height) {
-		Tile[][] tiles = new Tile[width][height];
-		for (int x = 0; x < tiles.length; x++) {
-			for (int y = 0; y < tiles[x].length; y++) {
-				tiles[x][y] = new Tile(new Position(x, y));
-			}
-		}
-		return tiles;
-	}
-	
-	public Tile[][] getTiles() {
-		return tiles;
-	}
+    private static Tile[][] initTiles(int width, int height) {
+        Tile[][] tiles = new Tile[width][height];
+        for (int x = 0; x < tiles.length; x++) {
+            for (int y = 0; y < tiles[x].length; y++) {
+                tiles[x][y] = new Tile(new Position(x, y));
+            }
+        }
+        return tiles;
+    }
 
-	public void putUnit(Unit unit, Position position) {
-		Tile tile = getTileAt(position);
-		tile.addUnit(unit);
-		units.put(unit.getId(), unit);
-	}
+    public Tile[][] getTiles() {
+        return tiles;
+    }
 
-	public void putHeadquarter(Headquarter hq, Position position) {
-		Tile tile = getTileAt(position);
-		tile.addHeadquarter(hq);
-		headquarters.add(hq);
-	}
+    public void putUnit(Unit unit, Position position) {
+        Tile tile = getTileAt(position);
+        tile.addUnit(unit);
+        units.put(unit.getId(), unit);
+    }
 
-	public void putResource(int resources, Position position) {
-		Tile tile = getTileAt(position);
-		tile.setResources(resources);
-	}
+    public void putHeadquarter(Headquarter hq, Position position) {
+        Tile tile = getTileAt(position);
+        tile.addHeadquarter(hq);
+        headquarters.add(hq);
+    }
 
-	public Unit getUnit(Player player, int unitId) {
-		Unit unit = units.get(Integer.valueOf(unitId));
-		if (unit == null) {
-			throw NoSuchAssetException.forUnit(unitId);
-		}
-		if (!player.equals(unit.getOwner())) {
-			throw NotUnitOwnerException.forPlayerAndUnit(player, unitId);
-		}
-		return unit;
-	}
+    public void putResource(int resources, Position position) {
+        Tile tile = getTileAt(position);
+        tile.setResources(resources);
+    }
 
-	public Tile getTileAt(Position targetPosition) {
-		return tiles[targetPosition.x][targetPosition.y];
-	}
+    public Unit getUnit(Player player, int unitId) {
+        Unit unit = units.get(Integer.valueOf(unitId));
+        if (unit == null) {
+            throw NoSuchAssetException.forUnit(unitId);
+        }
+        if (!player.equals(unit.getOwner())) {
+            throw NotUnitOwnerException.forPlayerAndUnit(player, unitId);
+        }
+        return unit;
+    }
 
-	public Position shift(Position position, Direction direction) {
-		return direction.shift(position).normalize(width, height);
-	}
+    public Tile getTileAt(Position targetPosition) {
+        return tiles[targetPosition.x][targetPosition.y];
+    }
 
-	public Headquarter getHeadQuarter(Player player) {
-		return headquarters.stream().filter(hq -> player.equals(hq.getOwner())).findFirst()
-				.orElseThrow(() -> NoSuchAssetException.forHeadquarter(player));
-	}
+    public Position shift(Position position, Direction direction) {
+        return direction.shift(position).normalize(width, height);
+    }
+
+    public Headquarter getHeadQuarter(Player player) {
+        return headquarters.stream().filter(hq -> player.equals(hq.getOwner())).findFirst()
+            .orElseThrow(() -> NoSuchAssetException.forHeadquarter(player));
+    }
 
 }

--- a/src/main/java/com/github/ocelotwars/engine/Position.java
+++ b/src/main/java/com/github/ocelotwars/engine/Position.java
@@ -3,48 +3,48 @@ package com.github.ocelotwars.engine;
 import java.util.Objects;
 
 public class Position {
-    
-	public int x;
-	public int y;
 
-	public Position(int x, int y) {
-		this.x = x;
-		this.y = y;
-	}
+    public int x;
+    public int y;
 
-	public Position normalize(int width, int height) {
-		int x = positiveModulo(this.x, width);
-		int y = positiveModulo(this.y, height);
-		return new Position(x, y);
-	}
+    public Position(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
 
-	private int positiveModulo(int i, int modulus) {
-		int result = i % modulus;
-		if (result < 0) {
-			result += modulus;
-		}
-		return result;
-	}
+    public Position normalize(int width, int height) {
+        int x = positiveModulo(this.x, width);
+        int y = positiveModulo(this.y, height);
+        return new Position(x, y);
+    }
 
-	@Override
-	public int hashCode() {
-		return Objects.hash(x, y);
-	}
+    private int positiveModulo(int i, int modulus) {
+        int result = i % modulus;
+        if (result < 0) {
+            result += modulus;
+        }
+        return result;
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null) {
-			return false;
-		}
-		if (getClass() != obj.getClass()) {
-			return false;
-		}
-		Position other = (Position) obj;
-		return other.x == x
-			&& other.y == y;
-	}
+    @Override
+    public int hashCode() {
+        return Objects.hash(x, y);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Position other = (Position) obj;
+        return other.x == x
+            && other.y == y;
+    }
 
 }

--- a/src/main/java/com/github/ocelotwars/engine/Tile.java
+++ b/src/main/java/com/github/ocelotwars/engine/Tile.java
@@ -7,64 +7,64 @@ import java.util.stream.Collectors;
 
 public class Tile {
 
-	private Position position;
-	private int resources;
-	private List<Asset> assets;
+    private Position position;
+    private int resources;
+    private List<Asset> assets;
 
-	public Tile(Position position) {
-		this.position = position;
-		this.assets = new ArrayList<>();
-	}
+    public Tile(Position position) {
+        this.position = position;
+        this.assets = new ArrayList<>();
+    }
 
-	public void setResources(int resources) {
-		this.resources = resources;
-	}
+    public void setResources(int resources) {
+        this.resources = resources;
+    }
 
-	public int getResources() {
-		return resources;
-	}
+    public int getResources() {
+        return resources;
+    }
 
-	public int removeResource() {
-		if (resources <= 0) {
-			return 0;
-		}
-		resources--;
-		return 1;
-	}
+    public int removeResource() {
+        if (resources <= 0) {
+            return 0;
+        }
+        resources--;
+        return 1;
+    }
 
-	public void addHeadquarter(Headquarter hq) {
-		hq.setTile(this);
-		assets.add(hq);
-	}
+    public void addHeadquarter(Headquarter hq) {
+        hq.setTile(this);
+        assets.add(hq);
+    }
 
-	public boolean hasHeadquarter(Player player) {
-		Optional<Headquarter> headquarter = assets.stream().filter(asset -> asset instanceof Headquarter)
-				.map(asset -> (Headquarter) asset).filter(hq -> player == null || hq.getOwner() == player).findFirst();
-		return headquarter.isPresent();
-	}
+    public boolean hasHeadquarter(Player player) {
+        Optional<Headquarter> headquarter = assets.stream().filter(asset -> asset instanceof Headquarter)
+            .map(asset -> (Headquarter) asset).filter(hq -> player == null || hq.getOwner() == player).findFirst();
+        return headquarter.isPresent();
+    }
 
-	public void addUnit(Unit unit) {
-		unit.setTile(this);
-		assets.add(unit);
-	}
+    public void addUnit(Unit unit) {
+        unit.setTile(this);
+        assets.add(unit);
+    }
 
-	public void removeUnit(Unit unit) {
-		assets.remove(unit);
-	}
-	
-	public List<Asset> getAssets() {
-		return assets;
-	}
+    public void removeUnit(Unit unit) {
+        assets.remove(unit);
+    }
 
-	public List<Unit> getUnits() {
-		return assets.stream()
-				.filter(asset -> asset instanceof Unit)
-				.map(asset -> (Unit) asset)
-				.collect(Collectors.toList());
-	}
+    public List<Asset> getAssets() {
+        return assets;
+    }
 
-	public Position getPosition() {
-		return position;
-	}
+    public List<Unit> getUnits() {
+        return assets.stream()
+            .filter(asset -> asset instanceof Unit)
+            .map(asset -> (Unit) asset)
+            .collect(Collectors.toList());
+    }
+
+    public Position getPosition() {
+        return position;
+    }
 
 }

--- a/src/main/java/com/github/ocelotwars/engine/command/GatherCommand.java
+++ b/src/main/java/com/github/ocelotwars/engine/command/GatherCommand.java
@@ -8,44 +8,44 @@ import com.github.ocelotwars.engine.Unit;
 public class GatherCommand implements Command {
 
     private Player player;
-	private int unitId;
+    private int unitId;
 
-	public GatherCommand(Player player, int unitId) {
-		this.player = player;
+    public GatherCommand(Player player, int unitId) {
+        this.player = player;
         this.unitId = unitId;
-	}
+    }
 
-	@Override
-	public void execute(Playground playground) {
-		Unit unit = playground.getUnit(player, unitId);
-		unit.gather();
-	}
+    @Override
+    public void execute(Playground playground) {
+        Unit unit = playground.getUnit(player, unitId);
+        unit.gather();
+    }
 
-	@Override
-	public int hashCode() {
-		return player.hashCode() * 13
-			+ unitId * 23
-			+ 29;
-	}
+    @Override
+    public int hashCode() {
+        return player.hashCode() * 13
+            + unitId * 23
+            + 29;
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null) {
-			return false;
-		}
-		if (getClass() != obj.getClass()) {
-			return false;
-		}
-		GatherCommand that = (GatherCommand) obj;
-		return this.player.equals(that.player)
-			&& this.unitId == that.unitId;
-	}
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        GatherCommand that = (GatherCommand) obj;
+        return this.player.equals(that.player)
+            && this.unitId == that.unitId;
+    }
 
-	@Override
-	public String toString() {
-		return player.toString() + ": " + unitId + " GATHER";
-	}
+    @Override
+    public String toString() {
+        return player.toString() + ": " + unitId + " GATHER";
+    }
 }

--- a/src/main/java/com/github/ocelotwars/engine/command/MoveCommand.java
+++ b/src/main/java/com/github/ocelotwars/engine/command/MoveCommand.java
@@ -10,52 +10,52 @@ import com.github.ocelotwars.engine.Unit;
 
 public class MoveCommand implements Command {
 
-	private Player player;
-	private int unitId;
-	private Direction direction;
+    private Player player;
+    private int unitId;
+    private Direction direction;
 
-	public MoveCommand(Player player, int unitId, Direction direction) {
-		this.player = player;
-		this.unitId = unitId;
-		this.direction = direction;
-	}
+    public MoveCommand(Player player, int unitId, Direction direction) {
+        this.player = player;
+        this.unitId = unitId;
+        this.direction = direction;
+    }
 
-	@Override
-	public void execute(Playground playground) {
-		Unit unit = playground.getUnit(player, unitId);
-		Position position = unit.getPosition();
-		Position targetPosition = playground.shift(position, direction);
-		Tile target = playground.getTileAt(targetPosition);
-		unit.moveTo(target);
-	}
+    @Override
+    public void execute(Playground playground) {
+        Unit unit = playground.getUnit(player, unitId);
+        Position position = unit.getPosition();
+        Position targetPosition = playground.shift(position, direction);
+        Tile target = playground.getTileAt(targetPosition);
+        unit.moveTo(target);
+    }
 
-	@Override
-	public int hashCode() {
-		return player.hashCode() * 7
-			+ unitId * 17
-			+ direction.hashCode() * 13
-			+ 31;
-	}
+    @Override
+    public int hashCode() {
+        return player.hashCode() * 7
+            + unitId * 17
+            + direction.hashCode() * 13
+            + 31;
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null) {
-			return false;
-		}
-		if (getClass() != obj.getClass()) {
-			return false;
-		}
-		MoveCommand that = (MoveCommand) obj;
-		return this.player.equals(that.player)
-			&& this.unitId == that.unitId
-			&& this.direction == that.direction;
-	}
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        MoveCommand that = (MoveCommand) obj;
+        return this.player.equals(that.player)
+            && this.unitId == that.unitId
+            && this.direction == that.direction;
+    }
 
-	@Override
-	public String toString() {
-		return player.toString() + ": " + unitId + " " + direction;
-	}
+    @Override
+    public String toString() {
+        return player.toString() + ": " + unitId + " " + direction;
+    }
 }

--- a/src/main/java/com/github/ocelotwars/engine/command/UnloadCommand.java
+++ b/src/main/java/com/github/ocelotwars/engine/command/UnloadCommand.java
@@ -9,44 +9,45 @@ import com.github.ocelotwars.engine.Unit;
 public class UnloadCommand implements Command {
 
     private Player player;
-	private int unitId;
+    private int unitId;
 
-	public UnloadCommand(Player player, int unitId) {
-		this.player = player;
+    public UnloadCommand(Player player, int unitId) {
+        this.player = player;
         this.unitId = unitId;
-	}
+    }
 
-	@Override
-	public void execute(Playground playground) {
-		Unit unit = playground.getUnit(player, unitId);
-		Headquarter headquarter = playground.getHeadQuarter(player);
-		unit.unload(headquarter);
-	}
-	@Override
-	public int hashCode() {
-		return player.hashCode() * 13
-			+ unitId * 23
-			+7;
-	}
+    @Override
+    public void execute(Playground playground) {
+        Unit unit = playground.getUnit(player, unitId);
+        Headquarter headquarter = playground.getHeadQuarter(player);
+        unit.unload(headquarter);
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null) {
-			return false;
-		}
-		if (getClass() != obj.getClass()) {
-			return false;
-		}
-		UnloadCommand that = (UnloadCommand) obj;
-		return this.player.equals(that.player)
-			&& this.unitId == that.unitId;
-	}
+    @Override
+    public int hashCode() {
+        return player.hashCode() * 13
+            + unitId * 23
+            + 7;
+    }
 
-	@Override
-	public String toString() {
-		return player.toString() + ": " + unitId + " UNLOAD";
-	}
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        UnloadCommand that = (UnloadCommand) obj;
+        return this.player.equals(that.player)
+            && this.unitId == that.unitId;
+    }
+
+    @Override
+    public String toString() {
+        return player.toString() + ": " + unitId + " UNLOAD";
+    }
 }

--- a/src/main/java/com/github/ocelotwars/engine/game/Game.java
+++ b/src/main/java/com/github/ocelotwars/engine/game/Game.java
@@ -7,15 +7,15 @@ import com.github.ocelotwars.engine.Playground;
 
 public class Game {
 
-	private Playground playground;
+    private Playground playground;
 
-	public Game(Playground playground) {
-		this.playground = playground;
-	}
+    public Game(Playground playground) {
+        this.playground = playground;
+    }
 
-	public Playground execute(List<Command> commands) {
-		commands.forEach(command -> command.execute(playground));
-		return playground;
-	}
+    public Playground execute(List<Command> commands) {
+        commands.forEach(command -> command.execute(playground));
+        return playground;
+    }
 
 }

--- a/src/main/java/com/github/ocelotwars/playgroundparser/PlaygroundFactory.java
+++ b/src/main/java/com/github/ocelotwars/playgroundparser/PlaygroundFactory.java
@@ -13,47 +13,47 @@ import com.github.ocelotwars.engine.Unit;
 
 public class PlaygroundFactory {
 
-	private Playground playground = null;
+    private Playground playground = null;
 
-	private int unitId = 0;
-	private SerializedPlayground serializedPlayground;
+    private int unitId = 0;
+    private SerializedPlayground serializedPlayground;
 
-	public Playground createPlayground(List<Player> players, String pathToFile) {
-		serializedPlayground = new SerializedPlayground(pathToFile);
-		playground = new Playground();
-		int height = serializedPlayground.getHeight();
-		int width = serializedPlayground.getWidth();
-		playground.init(width, height);
-		fillPlayground(players);
-		return playground;
-	}
+    public Playground createPlayground(List<Player> players, String pathToFile) {
+        serializedPlayground = new SerializedPlayground(pathToFile);
+        playground = new Playground();
+        int height = serializedPlayground.getHeight();
+        int width = serializedPlayground.getWidth();
+        playground.init(width, height);
+        fillPlayground(players);
+        return playground;
+    }
 
-	private void fillPlayground(List<Player> players) {
-		Iterator<Player> iterator = players.iterator();
-		for (int y = 0; y < serializedPlayground.getHeight(); y++) {
-			for (int x = 0; x < serializedPlayground.getWidth(); x++) {
-				handleTile(iterator, new Position(x, y));
-			}
-		}
+    private void fillPlayground(List<Player> players) {
+        Iterator<Player> iterator = players.iterator();
+        for (int y = 0; y < serializedPlayground.getHeight(); y++) {
+            for (int x = 0; x < serializedPlayground.getWidth(); x++) {
+                handleTile(iterator, new Position(x, y));
+            }
+        }
 
-	}
+    }
 
-	private void handleTile(Iterator<Player> iterator, Position position) {
-		if (serializedPlayground.hasHeadquarterAtPosition(position)) {
-			if (iterator.hasNext()) {
-				Player player = iterator.next();
-				playground.putHeadquarter(new Headquarter(player), position);
-				playground.putUnit(createUnit(player), position);
-			}
-		} else {
-			playground.putResource(valueOf(serializedPlayground.getTileAtPosition(position)), position);
-		}
-	}
+    private void handleTile(Iterator<Player> iterator, Position position) {
+        if (serializedPlayground.hasHeadquarterAtPosition(position)) {
+            if (iterator.hasNext()) {
+                Player player = iterator.next();
+                playground.putHeadquarter(new Headquarter(player), position);
+                playground.putUnit(createUnit(player), position);
+            }
+        } else {
+            playground.putResource(valueOf(serializedPlayground.getTileAtPosition(position)), position);
+        }
+    }
 
-	private Unit createUnit(Player player) {
-		unitId++;
-		Unit unit = new Unit(player, unitId);
-		return unit;
-	}
+    private Unit createUnit(Player player) {
+        unitId++;
+        Unit unit = new Unit(player, unitId);
+        return unit;
+    }
 
 }

--- a/src/main/java/com/github/ocelotwars/playgroundparser/SerializedPlayground.java
+++ b/src/main/java/com/github/ocelotwars/playgroundparser/SerializedPlayground.java
@@ -11,40 +11,40 @@ import java.util.stream.Collectors;
 import com.github.ocelotwars.engine.Position;
 
 public class SerializedPlayground {
-	private List<List<String>> tiles;
+    private List<List<String>> tiles;
 
-	public SerializedPlayground(String pathToFile) {
-		File file = new File(pathToFile);
-		Path path = file.toPath();
-		try {
-			setTiles(Files.lines(path).map(line -> line.split("\\|")).map(Arrays::asList).collect(Collectors.toList()));
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-	}
+    public SerializedPlayground(String pathToFile) {
+        File file = new File(pathToFile);
+        Path path = file.toPath();
+        try {
+            setTiles(Files.lines(path).map(line -> line.split("\\|")).map(Arrays::asList).collect(Collectors.toList()));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 
-	public List<List<String>> getTiles() {
-		return tiles;
-	}
+    public List<List<String>> getTiles() {
+        return tiles;
+    }
 
-	public void setTiles(List<List<String>> tiles) {
-		this.tiles = tiles;
-	}
+    public void setTiles(List<List<String>> tiles) {
+        this.tiles = tiles;
+    }
 
-	public int getHeight() {
-		return tiles.size();
-	}
+    public int getHeight() {
+        return tiles.size();
+    }
 
-	public int getWidth() {
-		return tiles.get(0).size();
-	}
+    public int getWidth() {
+        return tiles.get(0).size();
+    }
 
-	String getTileAtPosition(Position position) {
-		return tiles.get(position.y).get(position.x);
-	}
+    String getTileAtPosition(Position position) {
+        return tiles.get(position.y).get(position.x);
+    }
 
-	public boolean hasHeadquarterAtPosition(Position position) {
-		return getTileAtPosition(position).equals("H");
-	}
+    public boolean hasHeadquarterAtPosition(Position position) {
+        return getTileAtPosition(position).equals("H");
+    }
 
 }

--- a/src/main/java/com/github/ocelotwars/service/CommandFactory.java
+++ b/src/main/java/com/github/ocelotwars/service/CommandFactory.java
@@ -10,26 +10,26 @@ import com.github.ocelotwars.service.commands.Unload;
 
 public class CommandFactory {
 
-	private Player player;
+    private Player player;
 
-	public CommandFactory(Player player) {
-		this.player = player;
-	}
+    public CommandFactory(Player player) {
+        this.player = player;
+    }
 
-	public Command convertCommand(com.github.ocelotwars.service.commands.Command commandSrc) {
-		if (commandSrc instanceof Move) {
-			Move move = (Move) commandSrc;
-			return new MoveCommand(player, move.getUnitId(), convertDirection(move.getDirection()));
-		} else if (commandSrc instanceof Unload) {
-			return new UnloadCommand(player, commandSrc.getUnitId());
-		} else if (commandSrc instanceof Unload) {
-			return new UnloadCommand(player, commandSrc.getUnitId());
-		} else {
-			return Command.NULL;
-		}
-	}
+    public Command convertCommand(com.github.ocelotwars.service.commands.Command commandSrc) {
+        if (commandSrc instanceof Move) {
+            Move move = (Move) commandSrc;
+            return new MoveCommand(player, move.getUnitId(), convertDirection(move.getDirection()));
+        } else if (commandSrc instanceof Unload) {
+            return new UnloadCommand(player, commandSrc.getUnitId());
+        } else if (commandSrc instanceof Unload) {
+            return new UnloadCommand(player, commandSrc.getUnitId());
+        } else {
+            return Command.NULL;
+        }
+    }
 
-	public Direction convertDirection(com.github.ocelotwars.service.commands.Direction direction) {
-		return Direction.valueOf(direction.name());
-	}
+    public Direction convertDirection(com.github.ocelotwars.service.commands.Direction direction) {
+        return Direction.valueOf(direction.name());
+    }
 }

--- a/src/main/java/com/github/ocelotwars/service/Commands.java
+++ b/src/main/java/com/github/ocelotwars/service/Commands.java
@@ -7,18 +7,18 @@ import com.github.ocelotwars.service.commands.Command;
 
 public class Commands implements Message {
 
-	private List<Command> commands;
+    private List<Command> commands;
 
-	public Commands(List<Command> commands) {
-		this.commands = commands;
-	}
-	
-	public Commands() {
-		this.commands = new ArrayList<>();
-	}
-	
-	public List<Command> getCommands() {
-		return commands;
-	}
+    public Commands(List<Command> commands) {
+        this.commands = commands;
+    }
+
+    public Commands() {
+        this.commands = new ArrayList<>();
+    }
+
+    public List<Command> getCommands() {
+        return commands;
+    }
 
 }

--- a/src/main/java/com/github/ocelotwars/service/GameControl.java
+++ b/src/main/java/com/github/ocelotwars/service/GameControl.java
@@ -7,61 +7,61 @@ import rx.subjects.PublishSubject;
 
 public class GameControl extends Subscriber<GameControlMessage> {
 
-	private PublishSubject<SocketMessage> mq;
-	private PlayerRegistry allPlayers;
+    private PublishSubject<SocketMessage> mq;
+    private PlayerRegistry allPlayers;
 
-	public GameControl(PublishSubject<SocketMessage> mq) {
-		this.mq = mq;
-		this.allPlayers = new PlayerRegistry();
-	}
+    public GameControl(PublishSubject<SocketMessage> mq) {
+        this.mq = mq;
+        this.allPlayers = new PlayerRegistry();
+    }
 
-	public void init() {
-		this.mq
-			.map(msg -> msg.getMessage())
-			.filter(msg -> msg instanceof GameControlMessage)
-			.cast(GameControlMessage.class)
-			.subscribe(this);
-		this.mq
-			.filter(msg -> msg.getMessage() instanceof Register)
-			.subscribe(msg -> allPlayers.register(((Register) msg.getMessage()).getPlayerName(), msg.getSocket()));
-	}
+    public void init() {
+        this.mq
+            .map(msg -> msg.getMessage())
+            .filter(msg -> msg instanceof GameControlMessage)
+            .cast(GameControlMessage.class)
+            .subscribe(this);
+        this.mq
+            .filter(msg -> msg.getMessage() instanceof Register)
+            .subscribe(msg -> allPlayers.register(((Register) msg.getMessage()).getPlayerName(), msg.getSocket()));
+    }
 
-	@Override
-	public void onCompleted() {
-	}
+    @Override
+    public void onCompleted() {
+    }
 
-	@Override
-	public void onError(Throwable e) {
-	}
+    @Override
+    public void onError(Throwable e) {
+    }
 
-	@Override
-	public void onNext(GameControlMessage msg) {
-		if (msg instanceof Start) {
-			start();
-		} else if (msg instanceof Run) {
-			run(((Run) msg).getPlayers());
-		} else if (msg instanceof Stop) {
-			stop();
-		}
-	}
+    @Override
+    public void onNext(GameControlMessage msg) {
+        if (msg instanceof Start) {
+            start();
+        } else if (msg instanceof Run) {
+            run(((Run) msg).getPlayers());
+        } else if (msg instanceof Stop) {
+            stop();
+        }
+    }
 
-	private void start() {
-		Invitation invitation = new Invitation(allPlayers.getPlayers(), 10)
-			.invitePlayers(mq);
-		invitation.confirmedPlayers()
-			.subscribe(players -> mq.onNext(new SocketMessage(new Run(players))));
+    private void start() {
+        Invitation invitation = new Invitation(allPlayers.getPlayers(), 10)
+            .invitePlayers(mq);
+        invitation.confirmedPlayers()
+            .subscribe(players -> mq.onNext(new SocketMessage(new Run(players))));
 
-	}
+    }
 
-	private void run(List<SocketPlayer> players) {
-		GameSession session = new GameSession(players, 1)
-			.rounds(10, mq);
-		session.winner()
-			.subscribe(player -> mq.onNext(new SocketMessage(new Stop(player))));
-	}
+    private void run(List<SocketPlayer> players) {
+        GameSession session = new GameSession(players, 1)
+            .rounds(10, mq);
+        session.winner()
+            .subscribe(player -> mq.onNext(new SocketMessage(new Stop(player))));
+    }
 
-	private void stop() {
-		mq.onNext(new SocketMessage(new Start()));
-	}
+    private void stop() {
+        mq.onNext(new SocketMessage(new Start()));
+    }
 
 }

--- a/src/main/java/com/github/ocelotwars/service/GameSession.java
+++ b/src/main/java/com/github/ocelotwars/service/GameSession.java
@@ -25,100 +25,100 @@ import rx.subjects.PublishSubject;
 
 public class GameSession {
 
-	private int time;
-	private ObjectMapper mapper;
+    private int time;
+    private ObjectMapper mapper;
 
-	private List<SocketPlayer> players;
-	private Observable<Integer> round;
-	private PublishSubject<SocketPlayer> winner;
-	private Game game;
+    private List<SocketPlayer> players;
+    private Observable<Integer> round;
+    private PublishSubject<SocketPlayer> winner;
+    private Game game;
 
-	public GameSession(List<SocketPlayer> players, int time) {
-		this(new Game(new Playground()), players, time);
-	}
+    public GameSession(List<SocketPlayer> players, int time) {
+        this(new Game(new Playground()), players, time);
+    }
 
-	public GameSession(Game game, List<SocketPlayer> players, int time) {
-		this.time = time;
-		this.mapper = new ObjectMapper();
-		this.players = players;
-		this.round = Observable.just(0);
-		this.winner = PublishSubject.create();
-		this.game = game;
-	}
+    public GameSession(Game game, List<SocketPlayer> players, int time) {
+        this.time = time;
+        this.mapper = new ObjectMapper();
+        this.players = players;
+        this.round = Observable.just(0);
+        this.winner = PublishSubject.create();
+        this.game = game;
+    }
 
-	private String json(OutMessage msg) {
-		try {
-			return mapper.writeValueAsString(msg);
-		} catch (IOException e) {
-			return null;
-		}
-	}
+    private String json(OutMessage msg) {
+        try {
+            return mapper.writeValueAsString(msg);
+        } catch (IOException e) {
+            return null;
+        }
+    }
 
-	public void notifyPlayers() {
-		for (SocketPlayer player : players) {
-			notify(player);
-		}
-	}
+    public void notifyPlayers() {
+        for (SocketPlayer player : players) {
+            notify(player);
+        }
+    }
 
-	private void notify(SocketPlayer player) {
-		ServerWebSocket socket = player.getSocket();
-		socket.writeFinalTextFrame(json(new Notify()));
-	}
+    private void notify(SocketPlayer player) {
+        ServerWebSocket socket = player.getSocket();
+        socket.writeFinalTextFrame(json(new Notify()));
+    }
 
-	public GameSession rounds(int no, Observable<SocketMessage> mq) {
-		for (int i = 0; i < no; i++) {
-			round = round.flatMap(round -> round(round, mq));
-		}
-		round.subscribe(round -> {
-			winner.onNext(players.get(0)); // TODO return the player that is winner
-		});
-		return this;
-	}
+    public GameSession rounds(int no, Observable<SocketMessage> mq) {
+        for (int i = 0; i < no; i++) {
+            round = round.flatMap(round -> round(round, mq));
+        }
+        round.subscribe(round -> {
+            winner.onNext(players.get(0)); // TODO return the player that is winner
+        });
+        return this;
+    }
 
-	protected Observable<Integer> round(int round, Observable<SocketMessage> mq) {
-		PublishSubject<Integer> ready = PublishSubject.create();
-		mq
-			.take(time, TimeUnit.SECONDS)
-			.distinct(SocketMessage::getSocket)
-			.filter(msg -> msg.getMessage() instanceof Commands)
-			.doOnUnsubscribe(() -> ready.onNext(round + 1))
-			.subscribe(msg -> executeGame(msg.getSocket(), (Commands) msg.getMessage()));
-		notifyPlayers();
-		return ready;
-	}
+    protected Observable<Integer> round(int round, Observable<SocketMessage> mq) {
+        PublishSubject<Integer> ready = PublishSubject.create();
+        mq
+            .take(time, TimeUnit.SECONDS)
+            .distinct(SocketMessage::getSocket)
+            .filter(msg -> msg.getMessage() instanceof Commands)
+            .doOnUnsubscribe(() -> ready.onNext(round + 1))
+            .subscribe(msg -> executeGame(msg.getSocket(), (Commands) msg.getMessage()));
+        notifyPlayers();
+        return ready;
+    }
 
-	public void executeGame(ServerWebSocket socket, Commands webCommands) {
-			players.stream()
-				.filter(player -> player.getSocket() == socket)
-				.findFirst()
-				.ifPresent(webPlayer -> {
-					List<com.github.ocelotwars.engine.Command> commands = convertCommands(webPlayer, webCommands.getCommands());
-					game.execute(commands);
-				});
-	}
+    public void executeGame(ServerWebSocket socket, Commands webCommands) {
+        players.stream()
+            .filter(player -> player.getSocket() == socket)
+            .findFirst()
+            .ifPresent(webPlayer -> {
+                List<com.github.ocelotwars.engine.Command> commands = convertCommands(webPlayer, webCommands.getCommands());
+                game.execute(commands);
+            });
+    }
 
-	private List<com.github.ocelotwars.engine.Command> convertCommands(SocketPlayer player, List<Command> commands) {
-		return commands.stream()
-			.map(command -> convertCommand(command, player.getPlayer()))
-			.collect(toList());
-	}
+    private List<com.github.ocelotwars.engine.Command> convertCommands(SocketPlayer player, List<Command> commands) {
+        return commands.stream()
+            .map(command -> convertCommand(command, player.getPlayer()))
+            .collect(toList());
+    }
 
-	private com.github.ocelotwars.engine.Command convertCommand(Command command, Player player) {
-		if (command instanceof Gather) {
-			return new GatherCommand(player, command.getUnitId());
-		} else if (command instanceof Move) {
-			Direction direction = ((Move) command).getDirection();
-			com.github.ocelotwars.engine.Direction dir = com.github.ocelotwars.engine.Direction.valueOf(direction.name());
-			return new MoveCommand(player, command.getUnitId(), dir);
-		} else if (command instanceof Unload) {
-			return new UnloadCommand(player, command.getUnitId());
-		} else {
-			return null;
-		}
-	}
+    private com.github.ocelotwars.engine.Command convertCommand(Command command, Player player) {
+        if (command instanceof Gather) {
+            return new GatherCommand(player, command.getUnitId());
+        } else if (command instanceof Move) {
+            Direction direction = ((Move) command).getDirection();
+            com.github.ocelotwars.engine.Direction dir = com.github.ocelotwars.engine.Direction.valueOf(direction.name());
+            return new MoveCommand(player, command.getUnitId(), dir);
+        } else if (command instanceof Unload) {
+            return new UnloadCommand(player, command.getUnitId());
+        } else {
+            return null;
+        }
+    }
 
-	public Observable<SocketPlayer> winner() {
-		return winner;
-	}
+    public Observable<SocketPlayer> winner() {
+        return winner;
+    }
 
 }

--- a/src/main/java/com/github/ocelotwars/service/Host.java
+++ b/src/main/java/com/github/ocelotwars/service/Host.java
@@ -15,46 +15,47 @@ import rx.subjects.PublishSubject;
 
 public class Host extends AbstractVerticle {
 
-	private PublishSubject<SocketMessage> mq;
-	private GameControl gameControl;
+    private PublishSubject<SocketMessage> mq;
+    private GameControl gameControl;
 
-	public Host() {
-		mq = PublishSubject.create();
-		timer(5, TimeUnit.SECONDS)
-			.map(value -> new SocketMessage(new Start()))
-			.subscribe(msg -> mq.onNext(msg));
-		gameControl = new GameControl(mq);
-		gameControl.init();
-	}
+    public Host() {
+        mq = PublishSubject.create();
+        timer(5, TimeUnit.SECONDS)
+            .map(value -> new SocketMessage(new Start()))
+            .subscribe(msg -> mq.onNext(msg));
+        gameControl = new GameControl(mq);
+        gameControl.init();
+    }
 
-	@Override
-	public void start() {
-		HttpServer server = vertx.createHttpServer();
-		server.websocketHandler(this::websocket).listen(8080);
-		mq.subscribe(
-			msg -> System.out.println("mq: " + msg.getMessage().getClass().getSimpleName()),
-			e -> System.out.println("mq error " + e.getClass().getSimpleName()),
-			() -> {System.out.println("mq completed");}
-		);
-	}
+    @Override
+    public void start() {
+        HttpServer server = vertx.createHttpServer();
+        server.websocketHandler(this::websocket).listen(8080);
+        mq.subscribe(
+            msg -> System.out.println("mq: " + msg.getMessage().getClass().getSimpleName()),
+            e -> System.out.println("mq error " + e.getClass().getSimpleName()),
+            () -> {
+                System.out.println("mq completed");
+            });
+    }
 
-	public void websocket(ServerWebSocket socket) {
-		socket.frameHandler(frame -> message(frame, socket));
-	}
+    public void websocket(ServerWebSocket socket) {
+        socket.frameHandler(frame -> message(frame, socket));
+    }
 
-	public void message(WebSocketFrame frame, ServerWebSocket socket) {
-		String text = frame.textData();
-		Message msg = mapMessage(text);
-		mq.onNext(new SocketMessage(socket, msg));
-	}
+    public void message(WebSocketFrame frame, ServerWebSocket socket) {
+        String text = frame.textData();
+        Message msg = mapMessage(text);
+        mq.onNext(new SocketMessage(socket, msg));
+    }
 
-	protected Message mapMessage(String message) {
-		ObjectMapper mapper = new ObjectMapper();
-		try {
-			return mapper.readValue(message, Message.class);
-		} catch (IOException e) {
-			return null;
-		}
-	}
+    protected Message mapMessage(String message) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            return mapper.readValue(message, Message.class);
+        } catch (IOException e) {
+            return null;
+        }
+    }
 
 }

--- a/src/main/java/com/github/ocelotwars/service/Invitation.java
+++ b/src/main/java/com/github/ocelotwars/service/Invitation.java
@@ -14,51 +14,51 @@ import rx.subjects.PublishSubject;
 
 public class Invitation {
 
-	private ObjectMapper mapper;
+    private ObjectMapper mapper;
 
-	private Observable<SocketPlayer> players;
-	private PublishSubject<SocketPlayer> confirmed;
+    private Observable<SocketPlayer> players;
+    private PublishSubject<SocketPlayer> confirmed;
 
-	public Invitation(List<SocketPlayer> players, int time) {
-		this.mapper = new ObjectMapper();
-		this.players = Observable.from(players);
-		this.confirmed = PublishSubject.create();
-		timer(time, TimeUnit.SECONDS)
-			.first()
-			.subscribe(t -> confirmed.onCompleted());
-	}
+    public Invitation(List<SocketPlayer> players, int time) {
+        this.mapper = new ObjectMapper();
+        this.players = Observable.from(players);
+        this.confirmed = PublishSubject.create();
+        timer(time, TimeUnit.SECONDS)
+            .first()
+            .subscribe(t -> confirmed.onCompleted());
+    }
 
-	private String json(OutMessage msg) {
-		try {
-			return mapper.writeValueAsString(msg);
-		} catch (IOException e) {
-			return null;
-		}
-	}
+    private String json(OutMessage msg) {
+        try {
+            return mapper.writeValueAsString(msg);
+        } catch (IOException e) {
+            return null;
+        }
+    }
 
-	public Invitation invitePlayers(Observable<SocketMessage> mq) {
-		mq
-			.filter(msg -> msg.getMessage() instanceof Accept)
-			.subscribe(accept -> confirm(accept.getSocket()));
-		players
-			.subscribe(player -> invite(player));
+    public Invitation invitePlayers(Observable<SocketMessage> mq) {
+        mq
+            .filter(msg -> msg.getMessage() instanceof Accept)
+            .subscribe(accept -> confirm(accept.getSocket()));
+        players
+            .subscribe(player -> invite(player));
 
-		return this;
-	}
+        return this;
+    }
 
-	private void invite(SocketPlayer player) {
-		ServerWebSocket socket = player.getSocket();
-		socket.writeFinalTextFrame(json(new Invite()));
-	}
+    private void invite(SocketPlayer player) {
+        ServerWebSocket socket = player.getSocket();
+        socket.writeFinalTextFrame(json(new Invite()));
+    }
 
-	public void confirm(ServerWebSocket socket) {
-		players
-			.filter(player -> player.getSocket() == socket)
-			.subscribe(player -> confirmed.onNext(player));
-	}
+    public void confirm(ServerWebSocket socket) {
+        players
+            .filter(player -> player.getSocket() == socket)
+            .subscribe(player -> confirmed.onNext(player));
+    }
 
-	public Observable<List<SocketPlayer>> confirmedPlayers() {
-		return confirmed.toList();
-	}
+    public Observable<List<SocketPlayer>> confirmedPlayers() {
+        return confirmed.toList();
+    }
 
 }

--- a/src/main/java/com/github/ocelotwars/service/Message.java
+++ b/src/main/java/com/github/ocelotwars/service/Message.java
@@ -6,12 +6,12 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = As.PROPERTY, property = "@type")
-@JsonSubTypes({ 
-	@Type(name = "register", value = Register.class),
-	@Type(name = "invite", value = Invite.class),
-	@Type(name = "accept", value = Accept.class),
-	@Type(name = "commands", value = Commands.class)
-	})
+@JsonSubTypes({
+    @Type(name = "register", value = Register.class),
+    @Type(name = "invite", value = Invite.class),
+    @Type(name = "accept", value = Accept.class),
+    @Type(name = "commands", value = Commands.class)
+})
 public interface Message {
 
 }

--- a/src/main/java/com/github/ocelotwars/service/PlayerRegistry.java
+++ b/src/main/java/com/github/ocelotwars/service/PlayerRegistry.java
@@ -5,21 +5,21 @@ import java.util.List;
 
 import io.vertx.core.http.ServerWebSocket;
 
-public class PlayerRegistry  {
+public class PlayerRegistry {
 
-	private List<SocketPlayer> players;
-	
-	public PlayerRegistry() {
-		this.players = new LinkedList<>();
-	}
-	
-	public void register(String name, ServerWebSocket socket) {
-		players.removeIf(player -> player.getSocket() == socket);
-		players.add(new SocketPlayer(name, socket));
-	}
+    private List<SocketPlayer> players;
 
-	public List<SocketPlayer> getPlayers() {
-		return players;
-	}
+    public PlayerRegistry() {
+        this.players = new LinkedList<>();
+    }
+
+    public void register(String name, ServerWebSocket socket) {
+        players.removeIf(player -> player.getSocket() == socket);
+        players.add(new SocketPlayer(name, socket));
+    }
+
+    public List<SocketPlayer> getPlayers() {
+        return players;
+    }
 
 }

--- a/src/main/java/com/github/ocelotwars/service/Register.java
+++ b/src/main/java/com/github/ocelotwars/service/Register.java
@@ -2,10 +2,10 @@ package com.github.ocelotwars.service;
 
 public class Register implements Message {
 
-	private String playerName;
-	
-	public String getPlayerName() {
-		return playerName;
-	}
+    private String playerName;
+
+    public String getPlayerName() {
+        return playerName;
+    }
 
 }

--- a/src/main/java/com/github/ocelotwars/service/Run.java
+++ b/src/main/java/com/github/ocelotwars/service/Run.java
@@ -4,13 +4,13 @@ import java.util.List;
 
 public class Run implements GameControlMessage {
 
-	private List<SocketPlayer> players;
+    private List<SocketPlayer> players;
 
-	public Run(List<SocketPlayer> players) {
-		this.players = players;
-	}
+    public Run(List<SocketPlayer> players) {
+        this.players = players;
+    }
 
-	public List<SocketPlayer> getPlayers() {
-		return players;
-	}
+    public List<SocketPlayer> getPlayers() {
+        return players;
+    }
 }

--- a/src/main/java/com/github/ocelotwars/service/ServiceFacade.java
+++ b/src/main/java/com/github/ocelotwars/service/ServiceFacade.java
@@ -13,53 +13,53 @@ import com.github.ocelotwars.service.report.Unit;
 
 public class ServiceFacade {
 
-	public Playground convertPlayground(com.github.ocelotwars.engine.Playground playgroundSrc) {
-		Playground playground = new Playground();
-		playground.setTiles(convertTileMatrix(playgroundSrc.getTiles()));
-		return playground;
-	}
+    public Playground convertPlayground(com.github.ocelotwars.engine.Playground playgroundSrc) {
+        Playground playground = new Playground();
+        playground.setTiles(convertTileMatrix(playgroundSrc.getTiles()));
+        return playground;
+    }
 
-	public List<List<Tile>> convertTileMatrix(com.github.ocelotwars.engine.Tile[][] tiles) {
-		return Arrays.stream(tiles)
-			.map(this::convertTileArray)
-			.collect(toList());
-	}
+    public List<List<Tile>> convertTileMatrix(com.github.ocelotwars.engine.Tile[][] tiles) {
+        return Arrays.stream(tiles)
+            .map(this::convertTileArray)
+            .collect(toList());
+    }
 
-	public List<Tile> convertTileArray(com.github.ocelotwars.engine.Tile[] tiles) {
-		return Arrays.stream(tiles)
-			.map(this::convertTile)
-			.collect(toList());
-	}
+    public List<Tile> convertTileArray(com.github.ocelotwars.engine.Tile[] tiles) {
+        return Arrays.stream(tiles)
+            .map(this::convertTile)
+            .collect(toList());
+    }
 
-	public Tile convertTile(com.github.ocelotwars.engine.Tile tileSrc) {
-		Tile tile = new Tile();
-		tile.setAssets(convertAssets(tileSrc.getAssets()));
-		return tile;
-	}
+    public Tile convertTile(com.github.ocelotwars.engine.Tile tileSrc) {
+        Tile tile = new Tile();
+        tile.setAssets(convertAssets(tileSrc.getAssets()));
+        return tile;
+    }
 
-	public List<Asset> convertAssets(List<com.github.ocelotwars.engine.Asset> assets) {
-		return assets.stream()
-			.map(this::convertAsset)
-			.collect(toList());
-	}
+    public List<Asset> convertAssets(List<com.github.ocelotwars.engine.Asset> assets) {
+        return assets.stream()
+            .map(this::convertAsset)
+            .collect(toList());
+    }
 
-	public Asset convertAsset(com.github.ocelotwars.engine.Asset assetSrc) {
-		if (assetSrc instanceof com.github.ocelotwars.engine.Unit) {
-			com.github.ocelotwars.engine.Unit unitSrc = (com.github.ocelotwars.engine.Unit) assetSrc;
-			Unit unit = new Unit();
-			unit.setPlayer(unitSrc.getOwner().getName());
-			unit.setId(unitSrc.getId());
-			unit.setLoad(unitSrc.getLoad());
-			return unit;
-		} else if (assetSrc instanceof com.github.ocelotwars.engine.Headquarter) {
-			com.github.ocelotwars.engine.Headquarter hqSrc = (com.github.ocelotwars.engine.Headquarter) assetSrc;
-			Headquarter hq = new Headquarter();
-			hq.setPlayer(hqSrc.getOwner().getName());
-			hq.setResources(hqSrc.getResources());
-			return hq;
-		} else {
-			return null;
-		}
-	}
+    public Asset convertAsset(com.github.ocelotwars.engine.Asset assetSrc) {
+        if (assetSrc instanceof com.github.ocelotwars.engine.Unit) {
+            com.github.ocelotwars.engine.Unit unitSrc = (com.github.ocelotwars.engine.Unit) assetSrc;
+            Unit unit = new Unit();
+            unit.setPlayer(unitSrc.getOwner().getName());
+            unit.setId(unitSrc.getId());
+            unit.setLoad(unitSrc.getLoad());
+            return unit;
+        } else if (assetSrc instanceof com.github.ocelotwars.engine.Headquarter) {
+            com.github.ocelotwars.engine.Headquarter hqSrc = (com.github.ocelotwars.engine.Headquarter) assetSrc;
+            Headquarter hq = new Headquarter();
+            hq.setPlayer(hqSrc.getOwner().getName());
+            hq.setResources(hqSrc.getResources());
+            return hq;
+        } else {
+            return null;
+        }
+    }
 
 }

--- a/src/main/java/com/github/ocelotwars/service/SocketMessage.java
+++ b/src/main/java/com/github/ocelotwars/service/SocketMessage.java
@@ -4,24 +4,24 @@ import io.vertx.core.http.ServerWebSocket;
 
 public class SocketMessage {
 
-	private ServerWebSocket socket;
-	private Message message;
+    private ServerWebSocket socket;
+    private Message message;
 
-	public SocketMessage(ServerWebSocket socket, Message message) {
-		this.socket = socket;
-		this.message = message;
-	}
+    public SocketMessage(ServerWebSocket socket, Message message) {
+        this.socket = socket;
+        this.message = message;
+    }
 
-	public SocketMessage(Message message) {
-		this.message = message;
-	}
+    public SocketMessage(Message message) {
+        this.message = message;
+    }
 
-	public ServerWebSocket getSocket() {
-		return socket;
-	}
+    public ServerWebSocket getSocket() {
+        return socket;
+    }
 
-	public Message getMessage() {
-		return message;
-	}
+    public Message getMessage() {
+        return message;
+    }
 
 }

--- a/src/main/java/com/github/ocelotwars/service/SocketPlayer.java
+++ b/src/main/java/com/github/ocelotwars/service/SocketPlayer.java
@@ -6,24 +6,24 @@ import io.vertx.core.http.ServerWebSocket;
 
 public class SocketPlayer {
 
-	private Player player;
-	private ServerWebSocket socket;
+    private Player player;
+    private ServerWebSocket socket;
 
-	public SocketPlayer(String name, ServerWebSocket socket) {
-		this.player = new Player(name);
-		this.socket = socket;
-	}
-	
-	public Player getPlayer() {
-		return player;
-	}
+    public SocketPlayer(String name, ServerWebSocket socket) {
+        this.player = new Player(name);
+        this.socket = socket;
+    }
 
-	public String getName() {
-		return player.getName();
-	}
-	
-	public ServerWebSocket getSocket() {
-		return socket;
-	}
+    public Player getPlayer() {
+        return player;
+    }
+
+    public String getName() {
+        return player.getName();
+    }
+
+    public ServerWebSocket getSocket() {
+        return socket;
+    }
 
 }

--- a/src/main/java/com/github/ocelotwars/service/Stop.java
+++ b/src/main/java/com/github/ocelotwars/service/Stop.java
@@ -2,13 +2,13 @@ package com.github.ocelotwars.service;
 
 public class Stop implements GameControlMessage {
 
-	private SocketPlayer player;
+    private SocketPlayer player;
 
-	public Stop(SocketPlayer player) {
-		this.player = player;
-	}
-	
-	public SocketPlayer getPlayer() {
-		return player;
-	}
+    public Stop(SocketPlayer player) {
+        this.player = player;
+    }
+
+    public SocketPlayer getPlayer() {
+        return player;
+    }
 }

--- a/src/main/java/com/github/ocelotwars/service/commands/Command.java
+++ b/src/main/java/com/github/ocelotwars/service/commands/Command.java
@@ -1,18 +1,18 @@
 package com.github.ocelotwars.service.commands;
 
 public abstract class Command {
-	private int unitId;
+    private int unitId;
 
-	public Command(int unitId) {
-	    this.unitId = unitId;
-	}
+    public Command(int unitId) {
+        this.unitId = unitId;
+    }
 
-	public int getUnitId() {
-		return unitId;
-	}
-	
-	public void setUnitId(int unitId) {
-		this.unitId = unitId;
-	}
+    public int getUnitId() {
+        return unitId;
+    }
+
+    public void setUnitId(int unitId) {
+        this.unitId = unitId;
+    }
 
 }

--- a/src/main/java/com/github/ocelotwars/service/commands/Direction.java
+++ b/src/main/java/com/github/ocelotwars/service/commands/Direction.java
@@ -1,6 +1,6 @@
 package com.github.ocelotwars.service.commands;
 
 public enum Direction {
-	NORTH, EAST, SOUTH, WEST;
+    NORTH, EAST, SOUTH, WEST;
 
 }

--- a/src/main/java/com/github/ocelotwars/service/commands/Gather.java
+++ b/src/main/java/com/github/ocelotwars/service/commands/Gather.java
@@ -1,10 +1,9 @@
 package com.github.ocelotwars.service.commands;
 
-
 public class Gather extends Command {
 
-	public Gather(int unitId) {
-		super(unitId);
-	}
-	
+    public Gather(int unitId) {
+        super(unitId);
+    }
+
 }

--- a/src/main/java/com/github/ocelotwars/service/commands/Move.java
+++ b/src/main/java/com/github/ocelotwars/service/commands/Move.java
@@ -1,21 +1,20 @@
 package com.github.ocelotwars.service.commands;
 
-
 public class Move extends Command {
 
-	private Direction direction;
+    private Direction direction;
 
-	public Move(int unitId, Direction direction) {
-		super(unitId);
-		this.direction = direction;
-	}
-	
-	public Direction getDirection() {
-		return direction;
-	}
-	
-	public void setDirection(Direction direction) {
-		this.direction = direction;
-	}
+    public Move(int unitId, Direction direction) {
+        super(unitId);
+        this.direction = direction;
+    }
+
+    public Direction getDirection() {
+        return direction;
+    }
+
+    public void setDirection(Direction direction) {
+        this.direction = direction;
+    }
 
 }

--- a/src/main/java/com/github/ocelotwars/service/commands/Unload.java
+++ b/src/main/java/com/github/ocelotwars/service/commands/Unload.java
@@ -1,10 +1,9 @@
 package com.github.ocelotwars.service.commands;
 
-
 public class Unload extends Command {
 
-	public Unload(int unitId) {
-		super(unitId);
-	}
+    public Unload(int unitId) {
+        super(unitId);
+    }
 
 }

--- a/src/main/java/com/github/ocelotwars/service/report/Asset.java
+++ b/src/main/java/com/github/ocelotwars/service/report/Asset.java
@@ -2,13 +2,13 @@ package com.github.ocelotwars.service.report;
 
 public abstract class Asset {
 
-	private String player;
+    private String player;
 
-	public void setPlayer(String player) {
-		this.player = player;
-	}
-	
-	public String getPlayer() {
-		return player;
-	}
+    public void setPlayer(String player) {
+        this.player = player;
+    }
+
+    public String getPlayer() {
+        return player;
+    }
 }

--- a/src/main/java/com/github/ocelotwars/service/report/Headquarter.java
+++ b/src/main/java/com/github/ocelotwars/service/report/Headquarter.java
@@ -5,11 +5,11 @@ public class Headquarter extends Asset {
     private int resources;
 
     public int getResources() {
-		return resources;
-	}
-    
+        return resources;
+    }
+
     public void setResources(int resources) {
-		this.resources = resources;
-	}
-    
+        this.resources = resources;
+    }
+
 }

--- a/src/main/java/com/github/ocelotwars/service/report/Playground.java
+++ b/src/main/java/com/github/ocelotwars/service/report/Playground.java
@@ -4,17 +4,17 @@ import java.util.List;
 
 public class Playground {
 
-	private List<List<Tile>> tiles;
-	
-	public Playground() {
-	}
-	
-	public List<List<Tile>> getTiles() {
-		return tiles;
-	}
-	
-	public void setTiles(List<List<Tile>> tiles) {
-		this.tiles = tiles;
-	}
-	
+    private List<List<Tile>> tiles;
+
+    public Playground() {
+    }
+
+    public List<List<Tile>> getTiles() {
+        return tiles;
+    }
+
+    public void setTiles(List<List<Tile>> tiles) {
+        this.tiles = tiles;
+    }
+
 }

--- a/src/main/java/com/github/ocelotwars/service/report/Tile.java
+++ b/src/main/java/com/github/ocelotwars/service/report/Tile.java
@@ -3,30 +3,29 @@ package com.github.ocelotwars.service.report;
 import java.util.ArrayList;
 import java.util.List;
 
-
 public class Tile {
 
-	private int resources;
-	private List<Asset> assets;
+    private int resources;
+    private List<Asset> assets;
 
-	public Tile() {
-		this.assets = new ArrayList<>();
-	}
-	
-	public void setResources(int resources) {
-		this.resources = resources;
-	}
-	
-	public int getResources() {
-		return resources;
-	}
-	
-	public void setAssets(List<Asset> assets) {
-		this.assets = assets;
-	}
-	
-	public List<Asset> getAssets() {
-		return assets;
-	}
-	
+    public Tile() {
+        this.assets = new ArrayList<>();
+    }
+
+    public void setResources(int resources) {
+        this.resources = resources;
+    }
+
+    public int getResources() {
+        return resources;
+    }
+
+    public void setAssets(List<Asset> assets) {
+        this.assets = assets;
+    }
+
+    public List<Asset> getAssets() {
+        return assets;
+    }
+
 }

--- a/src/main/java/com/github/ocelotwars/service/report/Unit.java
+++ b/src/main/java/com/github/ocelotwars/service/report/Unit.java
@@ -2,22 +2,22 @@ package com.github.ocelotwars.service.report;
 
 public class Unit extends Asset {
 
-	private int id;
-	private int load;
+    private int id;
+    private int load;
 
-	public int getId() {
-		return id;
-	}
-	
-	public void setId(int id) {
-		this.id = id;
-	}
+    public int getId() {
+        return id;
+    }
 
-	public int getLoad() {
-		return load;
-	}
-	
-	public void setLoad(int load) {
-		this.load = load;
-	}
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public int getLoad() {
+        return load;
+    }
+
+    public void setLoad(int load) {
+        this.load = load;
+    }
 }

--- a/src/test/java/com/github/ocelotwars/engine/DirectionTest.java
+++ b/src/test/java/com/github/ocelotwars/engine/DirectionTest.java
@@ -8,37 +8,37 @@ import org.junit.Test;
 
 public class DirectionTest {
 
-	private final int x = 5;
-	private final int y = 12;
-	private final Position position = new Position(x, y);
+    private final int x = 5;
+    private final int y = 12;
+    private final Position position = new Position(x, y);
 
     @Test
     public void testEnum() {
         assertThat(Direction.class, isEnum().withElements(4));
     }
 
-	@Test
-	public void testShiftNorth() {
-		Position shifted = Direction.NORTH.shift(position);
-		assertThat(shifted, is(new Position(x, y - 1)));
-	}
+    @Test
+    public void testShiftNorth() {
+        Position shifted = Direction.NORTH.shift(position);
+        assertThat(shifted, is(new Position(x, y - 1)));
+    }
 
-	@Test
-	public void testShiftEast() {
-		Position shifted = Direction.EAST.shift(position);
-		assertThat(shifted, is(new Position(x + 1, y)));
-	}
+    @Test
+    public void testShiftEast() {
+        Position shifted = Direction.EAST.shift(position);
+        assertThat(shifted, is(new Position(x + 1, y)));
+    }
 
-	@Test
-	public void testShiftSouth() {
-		Position shifted = Direction.SOUTH.shift(position);
-		assertThat(shifted, is(new Position(x, y + 1)));
-	}
+    @Test
+    public void testShiftSouth() {
+        Position shifted = Direction.SOUTH.shift(position);
+        assertThat(shifted, is(new Position(x, y + 1)));
+    }
 
-	@Test
-	public void testShiftWest() {
-		Position shifted = Direction.WEST.shift(position);
-		assertThat(shifted, is(new Position(x - 1, y)));
-	}
+    @Test
+    public void testShiftWest() {
+        Position shifted = Direction.WEST.shift(position);
+        assertThat(shifted, is(new Position(x - 1, y)));
+    }
 
 }

--- a/src/test/java/com/github/ocelotwars/engine/PlaygroundBuilder.java
+++ b/src/test/java/com/github/ocelotwars/engine/PlaygroundBuilder.java
@@ -5,53 +5,53 @@ import java.util.List;
 
 public class PlaygroundBuilder {
 
-	private int height;
-	private int width;
-	private List<Headquarter> headquarters = new ArrayList<>();
-	private List<Unit> units = new ArrayList<>();
-	private List<Resource> resources = new ArrayList<>();
+    private int height;
+    private int width;
+    private List<Headquarter> headquarters = new ArrayList<>();
+    private List<Unit> units = new ArrayList<>();
+    private List<Resource> resources = new ArrayList<>();
 
-	private PlaygroundBuilder() {
-	}
+    private PlaygroundBuilder() {
+    }
 
-	public Playground create() {
-		Playground playground = new Playground();
-		playground.init(width, height);
-		Position position = new Position(4, 16);
-		headquarters.forEach(headquarter -> playground.putHeadquarter(headquarter, position));
-		units.forEach(unit -> playground.putUnit(unit, position));
-		resources.forEach(resource -> playground.putResource(resource.getValue(), resource.getPosition()));
+    public Playground create() {
+        Playground playground = new Playground();
+        playground.init(width, height);
+        Position position = new Position(4, 16);
+        headquarters.forEach(headquarter -> playground.putHeadquarter(headquarter, position));
+        units.forEach(unit -> playground.putUnit(unit, position));
+        resources.forEach(resource -> playground.putResource(resource.getValue(), resource.getPosition()));
 
-		return playground;
-	}
+        return playground;
+    }
 
-	public static PlaygroundBuilder playground() {
-		return new PlaygroundBuilder();
-	}
+    public static PlaygroundBuilder playground() {
+        return new PlaygroundBuilder();
+    }
 
-	public PlaygroundBuilder withHeight(int height) {
-		this.height = height;
-		return this;
-	}
+    public PlaygroundBuilder withHeight(int height) {
+        this.height = height;
+        return this;
+    }
 
-	public PlaygroundBuilder withWidth(int width) {
-		this.width = width;
-		return this;
-	}
+    public PlaygroundBuilder withWidth(int width) {
+        this.width = width;
+        return this;
+    }
 
-	public PlaygroundBuilder withHeadquarter(Headquarter headquarter) {
-		headquarters.add(headquarter);
-		return this;
-	}
+    public PlaygroundBuilder withHeadquarter(Headquarter headquarter) {
+        headquarters.add(headquarter);
+        return this;
+    }
 
-	public PlaygroundBuilder withUnit(Unit unit) {
-		units.add(unit);
-		return this;
-	}
+    public PlaygroundBuilder withUnit(Unit unit) {
+        units.add(unit);
+        return this;
+    }
 
-	public PlaygroundBuilder withResource(Position position, int resource) {
-		resources.add(new Resource(position, resource));
-		return this;
-	}
+    public PlaygroundBuilder withResource(Position position, int resource) {
+        resources.add(new Resource(position, resource));
+        return this;
+    }
 
 }

--- a/src/test/java/com/github/ocelotwars/engine/PlaygroundBuilderTest.java
+++ b/src/test/java/com/github/ocelotwars/engine/PlaygroundBuilderTest.java
@@ -7,32 +7,32 @@ import static org.junit.Assert.assertThat;
 import org.junit.Test;
 
 public class PlaygroundBuilderTest {
-	@Test
-	public void createsPlayground_widthAndHeight() throws Exception {
-		Playground playground = playground().withHeight(32).withWidth(32).create();
+    @Test
+    public void createsPlayground_widthAndHeight() throws Exception {
+        Playground playground = playground().withHeight(32).withWidth(32).create();
 
-		assertThat(playground.getTiles().length, is(32));
-		assertThat(playground.getTiles()[0].length, is(32));
-	}
+        assertThat(playground.getTiles().length, is(32));
+        assertThat(playground.getTiles()[0].length, is(32));
+    }
 
-	@Test
-	public void createsPlayground_HeadquarterAndUnitForPlayer() throws Exception {
-		Player player = new Player("Player");
-		Headquarter headquarter = new Headquarter(player);
-		Unit unit = new Unit(player, 1);
+    @Test
+    public void createsPlayground_HeadquarterAndUnitForPlayer() throws Exception {
+        Player player = new Player("Player");
+        Headquarter headquarter = new Headquarter(player);
+        Unit unit = new Unit(player, 1);
 
-		Playground playground = playground().withHeight(32).withWidth(32).withHeadquarter(headquarter).withUnit(unit)
-				.create();
+        Playground playground = playground().withHeight(32).withWidth(32).withHeadquarter(headquarter).withUnit(unit)
+            .create();
 
-		assertThat(playground.getHeadQuarter(player), is(headquarter));
-		assertThat(playground.getUnit(player, 1), is(unit));
-	}
+        assertThat(playground.getHeadQuarter(player), is(headquarter));
+        assertThat(playground.getUnit(player, 1), is(unit));
+    }
 
-	@Test
-	public void createsPlayground_resource() {
-		Position position = new Position(28, 16);
-		Playground playground = playground().withHeight(32).withWidth(32).withResource(position, 5).create();
+    @Test
+    public void createsPlayground_resource() {
+        Position position = new Position(28, 16);
+        Playground playground = playground().withHeight(32).withWidth(32).withResource(position, 5).create();
 
-		assertThat(playground.getTileAt(position).getResources(), is(5));
-	}
+        assertThat(playground.getTileAt(position).getResources(), is(5));
+    }
 }

--- a/src/test/java/com/github/ocelotwars/engine/PositionTest.java
+++ b/src/test/java/com/github/ocelotwars/engine/PositionTest.java
@@ -8,22 +8,22 @@ import org.junit.Test;
 
 public class PositionTest {
 
-	@Test
-	public void testEqualsHashcode() throws Exception {
-		assertThat(new Position(1, 2), satisfiesDefaultEquality()
-			.andEqualTo(new Position(1, 2))
-			.andNotEqualTo(new Position(2, 2))
-			.andNotEqualTo(new Position(1, 1))
-			.andNotEqualTo(new Position(2, 1)));
-	}
+    @Test
+    public void testEqualsHashcode() throws Exception {
+        assertThat(new Position(1, 2), satisfiesDefaultEquality()
+            .andEqualTo(new Position(1, 2))
+            .andNotEqualTo(new Position(2, 2))
+            .andNotEqualTo(new Position(1, 1))
+            .andNotEqualTo(new Position(2, 1)));
+    }
 
-	@Test
-	public void testNormalize() throws Exception {
-		assertThat(new Position(10, 10).normalize(4, 7), equalTo(new Position(2, 3)));
-	}
+    @Test
+    public void testNormalize() throws Exception {
+        assertThat(new Position(10, 10).normalize(4, 7), equalTo(new Position(2, 3)));
+    }
 
-	@Test
-	public void testNormalizeOnNegativePositions() throws Exception {
-		assertThat(new Position(-10, -10).normalize(4, 7), equalTo(new Position(2, 4)));
-	}
+    @Test
+    public void testNormalizeOnNegativePositions() throws Exception {
+        assertThat(new Position(-10, -10).normalize(4, 7), equalTo(new Position(2, 4)));
+    }
 }

--- a/src/test/java/com/github/ocelotwars/engine/Resource.java
+++ b/src/test/java/com/github/ocelotwars/engine/Resource.java
@@ -2,20 +2,20 @@ package com.github.ocelotwars.engine;
 
 public class Resource {
 
-	private Position position;
-	private int value;
+    private Position position;
+    private int value;
 
-	public Resource(Position position, int value) {
-		this.position = position;
-		this.value = value;
-	}
+    public Resource(Position position, int value) {
+        this.position = position;
+        this.value = value;
+    }
 
-	public Position getPosition() {
-		return position;
-	}
+    public Position getPosition() {
+        return position;
+    }
 
-	public int getValue() {
-		return value;
-	}
+    public int getValue() {
+        return value;
+    }
 
 }

--- a/src/test/java/com/github/ocelotwars/engine/command/GatherCommandTest.java
+++ b/src/test/java/com/github/ocelotwars/engine/command/GatherCommandTest.java
@@ -22,27 +22,28 @@ public class GatherCommandTest {
     private Player player2 = new Player("2");
     private Unit unit42 = new Unit(player1, 42);
 
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
-	private Playground playground;
+    private Playground playground;
 
-	@Before
-	public void before() {
-		playground = new Playground().init(9, 9);;
-	}
+    @Before
+    public void before() {
+        playground = new Playground().init(9, 9);
+        ;
+    }
 
-	@Test
-	public void testGatherOnUnitWithResourceTransfersResource() throws Exception {
-		playground.putUnit(unit42, pos(4, 4));
-		playground.putResource(1, pos(4, 4));
+    @Test
+    public void testGatherOnUnitWithResourceTransfersResource() throws Exception {
+        playground.putUnit(unit42, pos(4, 4));
+        playground.putResource(1, pos(4, 4));
 
-		GatherCommand command = new GatherCommand(player1, 42);
-		command.execute(playground);
+        GatherCommand command = new GatherCommand(player1, 42);
+        command.execute(playground);
 
-		assertThat(unit42.getLoad(), equalTo(1));
-		assertThat(playground.getTileAt(pos(4, 4)).getResources(), equalTo(0));
-	}
+        assertThat(unit42.getLoad(), equalTo(1));
+        assertThat(playground.getTileAt(pos(4, 4)).getResources(), equalTo(0));
+    }
 
     @Test
     public void testGatherOnLoadedUnitTransfersNoResource() throws Exception {
@@ -57,24 +58,24 @@ public class GatherCommandTest {
         assertThat(playground.getTileAt(pos(4, 4)).getResources(), equalTo(1));
     }
 
-	@Test
-	public void testGatherOnUnitWithoutResourceTransfersNoResource() throws Exception {
-		playground.putUnit(unit42, pos(4, 4));
+    @Test
+    public void testGatherOnUnitWithoutResourceTransfersNoResource() throws Exception {
+        playground.putUnit(unit42, pos(4, 4));
 
-		GatherCommand command = new GatherCommand(player1, 42);
-		command.execute(playground);
+        GatherCommand command = new GatherCommand(player1, 42);
+        command.execute(playground);
 
-		assertThat(unit42.getLoad(), equalTo(0));
-		assertThat(playground.getTileAt(pos(4, 4)).getResources(), equalTo(0));
-	}
+        assertThat(unit42.getLoad(), equalTo(0));
+        assertThat(playground.getTileAt(pos(4, 4)).getResources(), equalTo(0));
+    }
 
-	@Test
-	public void testGatherOnNoUnitThrowsException() throws Exception {
-		GatherCommand command = new GatherCommand(player1, 42);
-		
-		thrown.expect(NoSuchAssetException.class);
-		command.execute(playground);
-	}
+    @Test
+    public void testGatherOnNoUnitThrowsException() throws Exception {
+        GatherCommand command = new GatherCommand(player1, 42);
+
+        thrown.expect(NoSuchAssetException.class);
+        command.execute(playground);
+    }
 
     @Test
     public void testGatherOnForeignUnitThrowsException() throws Exception {
@@ -86,15 +87,15 @@ public class GatherCommandTest {
     }
 
     private Position pos(int x, int y) {
-		return new Position(x, y);
-	}
+        return new Position(x, y);
+    }
 
-	@Test
-	public void testEquals() throws Exception {
-		assertThat(new GatherCommand(new Player("Player1"), 42), satisfiesDefaultEquality()
-			.andEqualTo(new GatherCommand(new Player("Player1"), 42))
-			.andNotEqualTo(new GatherCommand(new Player("Player2"), 42))
-			.andNotEqualTo(new GatherCommand(new Player("Player1"), 41)));
-	}
+    @Test
+    public void testEquals() throws Exception {
+        assertThat(new GatherCommand(new Player("Player1"), 42), satisfiesDefaultEquality()
+            .andEqualTo(new GatherCommand(new Player("Player1"), 42))
+            .andNotEqualTo(new GatherCommand(new Player("Player2"), 42))
+            .andNotEqualTo(new GatherCommand(new Player("Player1"), 41)));
+    }
 
 }

--- a/src/test/java/com/github/ocelotwars/engine/command/MoveCommandTest.java
+++ b/src/test/java/com/github/ocelotwars/engine/command/MoveCommandTest.java
@@ -20,75 +20,75 @@ import com.github.ocelotwars.engine.Unit;
 
 public class MoveCommandTest {
 
-	private Player player1 = new Player("1");
-	private Player player2 = new Player("2");
-	private Unit unit42 = new Unit(player1, 42);
+    private Player player1 = new Player("1");
+    private Player player2 = new Player("2");
+    private Unit unit42 = new Unit(player1, 42);
 
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
-	private Playground playground;
+    private Playground playground;
 
-	@Before
-	public void before() {
-		playground = new Playground().init(9, 9);
-	}
+    @Before
+    public void before() {
+        playground = new Playground().init(9, 9);
+    }
 
-	@Test
-	public void testMoveRemovesUnitFromOriginTile() throws Exception {
-		playground.putUnit(unit42, pos(4, 4));
-		MoveCommand command = new MoveCommand(player1, 42, Direction.NORTH);
-		command.execute(playground);
+    @Test
+    public void testMoveRemovesUnitFromOriginTile() throws Exception {
+        playground.putUnit(unit42, pos(4, 4));
+        MoveCommand command = new MoveCommand(player1, 42, Direction.NORTH);
+        command.execute(playground);
 
-		assertThat(playground.getTileAt(pos(4, 4)).getUnits(), empty());
-	}
+        assertThat(playground.getTileAt(pos(4, 4)).getUnits(), empty());
+    }
 
-	@Test
-	public void testMoveAddsUnitToTargetTile() throws Exception {
-		playground.putUnit(unit42, pos(4, 4));
-		MoveCommand command = new MoveCommand(player1, 42, Direction.NORTH);
-		command.execute(playground);
+    @Test
+    public void testMoveAddsUnitToTargetTile() throws Exception {
+        playground.putUnit(unit42, pos(4, 4));
+        MoveCommand command = new MoveCommand(player1, 42, Direction.NORTH);
+        command.execute(playground);
 
-		assertThat(playground.getTileAt(pos(4, 3)).getUnits(), contains(unit42));
-	}
+        assertThat(playground.getTileAt(pos(4, 3)).getUnits(), contains(unit42));
+    }
 
-	@Test
-	public void testMoveSetsTileForUnit() throws Exception {
-		playground.putUnit(unit42, pos(4, 4));
-		MoveCommand command = new MoveCommand(player1, 42, Direction.NORTH);
-		command.execute(playground);
+    @Test
+    public void testMoveSetsTileForUnit() throws Exception {
+        playground.putUnit(unit42, pos(4, 4));
+        MoveCommand command = new MoveCommand(player1, 42, Direction.NORTH);
+        command.execute(playground);
 
-		assertThat(playground.getTileAt(pos(4, 3)).getUnits(), contains(unit42));
-	}
+        assertThat(playground.getTileAt(pos(4, 3)).getUnits(), contains(unit42));
+    }
 
-	@Test
-	public void testThrowsExceptionOnUnknownUnit() throws Exception {
-		MoveCommand command = new MoveCommand(player1, 42, Direction.NORTH);
+    @Test
+    public void testThrowsExceptionOnUnknownUnit() throws Exception {
+        MoveCommand command = new MoveCommand(player1, 42, Direction.NORTH);
 
-		thrown.expect(NoSuchAssetException.class);
-		command.execute(playground);
-	}
+        thrown.expect(NoSuchAssetException.class);
+        command.execute(playground);
+    }
 
-	@Test
-	public void testThrowsExceptionOnForeignUnit() throws Exception {
-		playground.putUnit(unit42, pos(4, 4));
-		MoveCommand command = new MoveCommand(player2, 42, Direction.NORTH);
+    @Test
+    public void testThrowsExceptionOnForeignUnit() throws Exception {
+        playground.putUnit(unit42, pos(4, 4));
+        MoveCommand command = new MoveCommand(player2, 42, Direction.NORTH);
 
-		thrown.expect(NotUnitOwnerException.class);
-		command.execute(playground);
-	}
+        thrown.expect(NotUnitOwnerException.class);
+        command.execute(playground);
+    }
 
-	@Test
-	public void testEquals() throws Exception {
-		assertThat(new MoveCommand(new Player("Player1"), 42, Direction.NORTH), satisfiesDefaultEquality()
-			.andEqualTo(new MoveCommand(new Player("Player1"), 42, Direction.NORTH))
-			.andNotEqualTo(new MoveCommand(new Player("Player2"), 42, Direction.NORTH))
-			.andNotEqualTo(new MoveCommand(new Player("Player1"), 43, Direction.NORTH))
-			.andNotEqualTo(new MoveCommand(new Player("Player1"), 42, Direction.EAST)));
-	}
+    @Test
+    public void testEquals() throws Exception {
+        assertThat(new MoveCommand(new Player("Player1"), 42, Direction.NORTH), satisfiesDefaultEquality()
+            .andEqualTo(new MoveCommand(new Player("Player1"), 42, Direction.NORTH))
+            .andNotEqualTo(new MoveCommand(new Player("Player2"), 42, Direction.NORTH))
+            .andNotEqualTo(new MoveCommand(new Player("Player1"), 43, Direction.NORTH))
+            .andNotEqualTo(new MoveCommand(new Player("Player1"), 42, Direction.EAST)));
+    }
 
-	private Position pos(int x, int y) {
-		return new Position(x, y);
-	}
+    private Position pos(int x, int y) {
+        return new Position(x, y);
+    }
 
 }

--- a/src/test/java/com/github/ocelotwars/engine/command/UnloadCommandTest.java
+++ b/src/test/java/com/github/ocelotwars/engine/command/UnloadCommandTest.java
@@ -19,97 +19,97 @@ import com.github.ocelotwars.engine.Unit;
 
 public class UnloadCommandTest {
 
-	private Player player1 = new Player("1");
-	private Player player2 = new Player("2");
-	private Headquarter hq1 = new Headquarter(player1);
-	private Unit unit42 = new Unit(player1, 42);
+    private Player player1 = new Player("1");
+    private Player player2 = new Player("2");
+    private Headquarter hq1 = new Headquarter(player1);
+    private Unit unit42 = new Unit(player1, 42);
 
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
-	private Playground playground;
+    private Playground playground;
 
-	@Before
-	public void before() {
-		playground = new Playground().init(9, 9);
+    @Before
+    public void before() {
+        playground = new Playground().init(9, 9);
 
-	}
+    }
 
-	@Test
-	public void testUnloadOnUnitAndHqWithResourceTransfersResource() throws Exception {
-		playground.putUnit(unit42, pos(4, 4));
-		unit42.setLoad(1);
-		playground.putHeadquarter(hq1, pos(4, 4));
+    @Test
+    public void testUnloadOnUnitAndHqWithResourceTransfersResource() throws Exception {
+        playground.putUnit(unit42, pos(4, 4));
+        unit42.setLoad(1);
+        playground.putHeadquarter(hq1, pos(4, 4));
 
-		UnloadCommand command = new UnloadCommand(player1, 42);
-		command.execute(playground);
+        UnloadCommand command = new UnloadCommand(player1, 42);
+        command.execute(playground);
 
-		assertThat(unit42.getLoad(), equalTo(0));
-		assertThat(hq1.getResources(), equalTo(1));
-	}
+        assertThat(unit42.getLoad(), equalTo(0));
+        assertThat(hq1.getResources(), equalTo(1));
+    }
 
-	@Test
-	public void testUnloadOnUnitAndNoHqInRangeWithResourceTransfersResource() throws Exception {
-		playground.putUnit(unit42, pos(4, 4));
-		unit42.setLoad(1);
-		playground.putHeadquarter(hq1, pos(4, 3));
+    @Test
+    public void testUnloadOnUnitAndNoHqInRangeWithResourceTransfersResource() throws Exception {
+        playground.putUnit(unit42, pos(4, 4));
+        unit42.setLoad(1);
+        playground.putHeadquarter(hq1, pos(4, 3));
 
-		UnloadCommand command = new UnloadCommand(player1, 42);
-		command.execute(playground);
+        UnloadCommand command = new UnloadCommand(player1, 42);
+        command.execute(playground);
 
-		assertThat(unit42.getLoad(), equalTo(1));
-		assertThat(hq1.getResources(), equalTo(0));
-	}
+        assertThat(unit42.getLoad(), equalTo(1));
+        assertThat(hq1.getResources(), equalTo(0));
+    }
 
-	@Test
-	public void testGatherOnUnitWithoutResourceTransfersNoResource() throws Exception {
-		playground.putUnit(unit42, pos(4, 4));
-		playground.putHeadquarter(hq1, pos(4, 4));
+    @Test
+    public void testGatherOnUnitWithoutResourceTransfersNoResource() throws Exception {
+        playground.putUnit(unit42, pos(4, 4));
+        playground.putHeadquarter(hq1, pos(4, 4));
 
-		UnloadCommand command = new UnloadCommand(player1, 42);
-		command.execute(playground);
+        UnloadCommand command = new UnloadCommand(player1, 42);
+        command.execute(playground);
 
-		assertThat(unit42.getLoad(), equalTo(0));
-		assertThat(hq1.getResources(), equalTo(0));
-	}
+        assertThat(unit42.getLoad(), equalTo(0));
+        assertThat(hq1.getResources(), equalTo(0));
+    }
 
-	@Test
-	public void testUnloadOnUnitAndNoHqThrowsException() throws Exception {
-		playground.putUnit(unit42, pos(4, 4));
-		unit42.setLoad(1);
-		UnloadCommand command = new UnloadCommand(player1, 42);
+    @Test
+    public void testUnloadOnUnitAndNoHqThrowsException() throws Exception {
+        playground.putUnit(unit42, pos(4, 4));
+        unit42.setLoad(1);
+        UnloadCommand command = new UnloadCommand(player1, 42);
 
-		thrown.expect(NoSuchAssetException.class);
-		command.execute(playground);
-	}
+        thrown.expect(NoSuchAssetException.class);
+        command.execute(playground);
+    }
 
-	@Test
-	public void testGatherOnNoUnitThrowsException() throws Exception {
-		UnloadCommand command = new UnloadCommand(player1, 42);
+    @Test
+    public void testGatherOnNoUnitThrowsException() throws Exception {
+        UnloadCommand command = new UnloadCommand(player1, 42);
 
-		thrown.expect(NoSuchAssetException.class);
-		command.execute(playground);
-	}
+        thrown.expect(NoSuchAssetException.class);
+        command.execute(playground);
+    }
 
-	@Test
-	public void testGatherOnForeignUnitThrowsException() throws Exception {
-		playground.putUnit(unit42, pos(4, 4));
-		UnloadCommand command = new UnloadCommand(player2, 42);
+    @Test
+    public void testGatherOnForeignUnitThrowsException() throws Exception {
+        playground.putUnit(unit42, pos(4, 4));
+        UnloadCommand command = new UnloadCommand(player2, 42);
 
-		thrown.expect(NotUnitOwnerException.class);
-		command.execute(playground);
-	}
+        thrown.expect(NotUnitOwnerException.class);
+        command.execute(playground);
+    }
 
-	@Test
-	public void testEquals() throws Exception {
-		assertThat(new UnloadCommand(new Player("Player1"), 42), satisfiesDefaultEquality()
-			.andEqualTo(new UnloadCommand(new Player("Player1"), 42))
-			.andNotEqualTo(new UnloadCommand(new Player("Player2"), 42))
-			.andNotEqualTo(new UnloadCommand(new Player("Player1"), 41)));
-	}
+    @Test
+    public void testEquals() throws Exception {
+        assertThat(new UnloadCommand(new Player("Player1"), 42), satisfiesDefaultEquality()
+            .andEqualTo(new UnloadCommand(new Player("Player1"), 42))
+            .andNotEqualTo(new UnloadCommand(new Player("Player2"), 42))
+            .andNotEqualTo(new UnloadCommand(new Player("Player1"), 41)));
+    }
 
-	private Position pos(int x, int y) {
-		return new Position(x, y);
-	}
+    private Position pos(int x, int y) {
+        return new Position(x, y);
+    }
 
 }

--- a/src/test/java/com/github/ocelotwars/engine/game/GameTest.java
+++ b/src/test/java/com/github/ocelotwars/engine/game/GameTest.java
@@ -25,63 +25,63 @@ import com.github.ocelotwars.engine.game.Game;
 
 public class GameTest {
 
-	private Player player = new Player("Player");
-	private int unitId = 1;
+    private Player player = new Player("Player");
+    private int unitId = 1;
 
-	@Test
-	public void execute_EmptyListOfCommands() throws Exception {
-		Playground beforeExecution = createDefaultPlayground(player, unitId);
-		Game game = new Game(beforeExecution);
+    @Test
+    public void execute_EmptyListOfCommands() throws Exception {
+        Playground beforeExecution = createDefaultPlayground(player, unitId);
+        Game game = new Game(beforeExecution);
 
-		List<Command> commands = emptyList();
+        List<Command> commands = emptyList();
 
-		Playground afterExecution = game.execute(commands);
+        Playground afterExecution = game.execute(commands);
 
-		assertThat(afterExecution.getUnit(player, unitId).getPosition(),
-			is(beforeExecution.getUnit(player, unitId).getPosition()));
-	}
+        assertThat(afterExecution.getUnit(player, unitId).getPosition(),
+            is(beforeExecution.getUnit(player, unitId).getPosition()));
+    }
 
-	@Test
-	public void execute_OneMoveRight() throws Exception {
+    @Test
+    public void execute_OneMoveRight() throws Exception {
 
-		Playground beforeExecution = createDefaultPlayground(player, unitId);
-		Game game = new Game(beforeExecution);
+        Playground beforeExecution = createDefaultPlayground(player, unitId);
+        Game game = new Game(beforeExecution);
 
-		List<Command> commands = new ArrayList<>();
-		commands.add(new MoveCommand(player, unitId, EAST));
+        List<Command> commands = new ArrayList<>();
+        commands.add(new MoveCommand(player, unitId, EAST));
 
-		Playground afterExecution = game.execute(commands);
+        Playground afterExecution = game.execute(commands);
 
-		assertThat(afterExecution.getUnit(player, unitId).getPosition(), is(new Position(5, 16)));
-	}
+        assertThat(afterExecution.getUnit(player, unitId).getPosition(), is(new Position(5, 16)));
+    }
 
-	@Test
-	public void execute_gatheringOfResource() throws Exception {
+    @Test
+    public void execute_gatheringOfResource() throws Exception {
 
-		Playground beforeExecution = createDefaultPlayground(player, unitId);
-		Game game = new Game(beforeExecution);
+        Playground beforeExecution = createDefaultPlayground(player, unitId);
+        Game game = new Game(beforeExecution);
 
-		List<Command> commands = new ArrayList<>();
-		commands.add(new MoveCommand(player, unitId, EAST));
-		commands.add(new MoveCommand(player, unitId, EAST));
-		commands.add(new GatherCommand(player, unitId));
-		commands.add(new MoveCommand(player, unitId, WEST));
-		commands.add(new MoveCommand(player, unitId, WEST));
-		commands.add(new UnloadCommand(player, unitId));
+        List<Command> commands = new ArrayList<>();
+        commands.add(new MoveCommand(player, unitId, EAST));
+        commands.add(new MoveCommand(player, unitId, EAST));
+        commands.add(new GatherCommand(player, unitId));
+        commands.add(new MoveCommand(player, unitId, WEST));
+        commands.add(new MoveCommand(player, unitId, WEST));
+        commands.add(new UnloadCommand(player, unitId));
 
-		assertThat(beforeExecution.getHeadQuarter(player).getResources(), is(0));
-		Playground afterExecution = game.execute(commands);
-		assertThat(afterExecution.getHeadQuarter(player).getResources(), is(1));
-	}
+        assertThat(beforeExecution.getHeadQuarter(player).getResources(), is(0));
+        Playground afterExecution = game.execute(commands);
+        assertThat(afterExecution.getHeadQuarter(player).getResources(), is(1));
+    }
 
-	private Playground createDefaultPlayground(Player player, int unitId) {
-		Playground beforeExecution = playground().withHeight(32).withWidth(32).withHeadquarter(new Headquarter(player))
-			.withUnit(new Unit(player, unitId)).withResource(new Position(6, 16), 5).create();
-		return beforeExecution;
-	}
+    private Playground createDefaultPlayground(Player player, int unitId) {
+        Playground beforeExecution = playground().withHeight(32).withWidth(32).withHeadquarter(new Headquarter(player))
+            .withUnit(new Unit(player, unitId)).withResource(new Position(6, 16), 5).create();
+        return beforeExecution;
+    }
 
-	// Game kann Commands verarbeiten
+    // Game kann Commands verarbeiten
 
-	// Game hat Endbedingung
+    // Game hat Endbedingung
 
 }

--- a/src/test/java/com/github/ocelotwars/playgroundparser/PlaygroundFactoryTest.java
+++ b/src/test/java/com/github/ocelotwars/playgroundparser/PlaygroundFactoryTest.java
@@ -14,69 +14,69 @@ import com.github.ocelotwars.engine.Position;
 import com.github.ocelotwars.playgroundparser.PlaygroundFactory;
 
 public class PlaygroundFactoryTest {
-	
-	@Test
-	public void createPlaygroundFromFile_onePlayer() throws Exception {
-		PlaygroundFactory playgroundFactory = new PlaygroundFactory();
-		Player player = new Player("Test");
-		int unitId = 1;
 
-		Playground playground = playgroundFactory.createPlayground(Arrays.asList(player),
-			"src/main/resources/onePlayer");
+    @Test
+    public void createPlaygroundFromFile_onePlayer() throws Exception {
+        PlaygroundFactory playgroundFactory = new PlaygroundFactory();
+        Player player = new Player("Test");
+        int unitId = 1;
 
-		assertThat(playground.getTiles().length, is(7));
-		assertThat(playground.getTiles()[0].length, is(7));
-		assertThat(playground.getHeadQuarter(player).getTile().getPosition(), is(new Position(3, 4)));
-		assertThat(playground.getUnit(player, unitId).getPosition(), is(new Position(3, 4)));
+        Playground playground = playgroundFactory.createPlayground(Arrays.asList(player),
+            "src/main/resources/onePlayer");
 
-		assertThat(playground.getTileAt(new Position(1, 1)).getResources(), is(1));
-		assertThat(playground.getTileAt(new Position(5, 1)).getResources(), is(2));
-		assertThat(playground.getTileAt(new Position(1, 4)).getResources(), is(3));
-		assertThat(playground.getTileAt(new Position(6, 5)).getResources(), is(4));
-	}
+        assertThat(playground.getTiles().length, is(7));
+        assertThat(playground.getTiles()[0].length, is(7));
+        assertThat(playground.getHeadQuarter(player).getTile().getPosition(), is(new Position(3, 4)));
+        assertThat(playground.getUnit(player, unitId).getPosition(), is(new Position(3, 4)));
 
-	@Test
-	public void createPlaygroundFromFile_twoPlayers() throws Exception {
-		PlaygroundFactory playgroundFactory = new PlaygroundFactory();
-		Player player1 = new Player("Test1");
-		Player player2 = new Player("Test2");
-		int unitIdOfPlayer1 = 1;
-		int unitIdOfPlayer2 = 2;
+        assertThat(playground.getTileAt(new Position(1, 1)).getResources(), is(1));
+        assertThat(playground.getTileAt(new Position(5, 1)).getResources(), is(2));
+        assertThat(playground.getTileAt(new Position(1, 4)).getResources(), is(3));
+        assertThat(playground.getTileAt(new Position(6, 5)).getResources(), is(4));
+    }
 
-		Playground playground = playgroundFactory.createPlayground(Arrays.asList(player1, player2),
-			"src/main/resources/twoPlayers");
+    @Test
+    public void createPlaygroundFromFile_twoPlayers() throws Exception {
+        PlaygroundFactory playgroundFactory = new PlaygroundFactory();
+        Player player1 = new Player("Test1");
+        Player player2 = new Player("Test2");
+        int unitIdOfPlayer1 = 1;
+        int unitIdOfPlayer2 = 2;
 
-		assertThat(playground.getTiles().length, is(7));
-		assertThat(playground.getTiles()[0].length, is(7));
-		assertThat(playground.getHeadQuarter(player1).getTile().getPosition(), is(new Position(3, 1)));
-		assertThat(playground.getUnit(player1, unitIdOfPlayer1).getPosition(), is(new Position(3, 1)));
+        Playground playground = playgroundFactory.createPlayground(Arrays.asList(player1, player2),
+            "src/main/resources/twoPlayers");
 
-		assertThat(playground.getHeadQuarter(player2).getTile().getPosition(), is(new Position(3, 4)));
-		assertThat(playground.getUnit(player2, unitIdOfPlayer2).getPosition(), is(new Position(3, 4)));
+        assertThat(playground.getTiles().length, is(7));
+        assertThat(playground.getTiles()[0].length, is(7));
+        assertThat(playground.getHeadQuarter(player1).getTile().getPosition(), is(new Position(3, 1)));
+        assertThat(playground.getUnit(player1, unitIdOfPlayer1).getPosition(), is(new Position(3, 1)));
 
-		assertThat(playground.getTileAt(new Position(1, 1)).getResources(), is(1));
-		assertThat(playground.getTileAt(new Position(5, 1)).getResources(), is(2));
-		assertThat(playground.getTileAt(new Position(1, 4)).getResources(), is(3));
-		assertThat(playground.getTileAt(new Position(6, 5)).getResources(), is(4));
-	}
+        assertThat(playground.getHeadQuarter(player2).getTile().getPosition(), is(new Position(3, 4)));
+        assertThat(playground.getUnit(player2, unitIdOfPlayer2).getPosition(), is(new Position(3, 4)));
 
-	@Test
-	public void createPlaygroundFromFile_twoPlayers_notEnoughPlayers() throws Exception {
-		PlaygroundFactory playgroundFactory = new PlaygroundFactory();
-		Player player1 = new Player("Test1");
-		int unitIdOfPlayer1 = 1;
+        assertThat(playground.getTileAt(new Position(1, 1)).getResources(), is(1));
+        assertThat(playground.getTileAt(new Position(5, 1)).getResources(), is(2));
+        assertThat(playground.getTileAt(new Position(1, 4)).getResources(), is(3));
+        assertThat(playground.getTileAt(new Position(6, 5)).getResources(), is(4));
+    }
 
-		Playground playground = playgroundFactory.createPlayground(Arrays.asList(player1),
-			"src/main/resources/twoPlayers");
+    @Test
+    public void createPlaygroundFromFile_twoPlayers_notEnoughPlayers() throws Exception {
+        PlaygroundFactory playgroundFactory = new PlaygroundFactory();
+        Player player1 = new Player("Test1");
+        int unitIdOfPlayer1 = 1;
 
-		assertThat(playground.getTiles().length, is(7));
-		assertThat(playground.getTiles()[0].length, is(7));
-		assertThat(playground.getHeadQuarter(player1).getTile().getPosition(), is(new Position(3, 1)));
-		assertThat(playground.getUnit(player1, unitIdOfPlayer1).getPosition(), is(new Position(3, 1)));
+        Playground playground = playgroundFactory.createPlayground(Arrays.asList(player1),
+            "src/main/resources/twoPlayers");
 
-		assertThat(playground.getTileAt(new Position(1, 1)).getResources(), is(1));
-		assertThat(playground.getTileAt(new Position(5, 1)).getResources(), is(2));
-		assertThat(playground.getTileAt(new Position(1, 4)).getResources(), is(3));
-		assertThat(playground.getTileAt(new Position(6, 5)).getResources(), is(4));
-	}
+        assertThat(playground.getTiles().length, is(7));
+        assertThat(playground.getTiles()[0].length, is(7));
+        assertThat(playground.getHeadQuarter(player1).getTile().getPosition(), is(new Position(3, 1)));
+        assertThat(playground.getUnit(player1, unitIdOfPlayer1).getPosition(), is(new Position(3, 1)));
+
+        assertThat(playground.getTileAt(new Position(1, 1)).getResources(), is(1));
+        assertThat(playground.getTileAt(new Position(5, 1)).getResources(), is(2));
+        assertThat(playground.getTileAt(new Position(1, 4)).getResources(), is(3));
+        assertThat(playground.getTileAt(new Position(6, 5)).getResources(), is(4));
+    }
 }

--- a/src/test/java/com/github/ocelotwars/service/GameSessionTest.java
+++ b/src/test/java/com/github/ocelotwars/service/GameSessionTest.java
@@ -36,218 +36,218 @@ import rx.subjects.PublishSubject;
 
 public class GameSessionTest {
 
-	@Rule
-	public MockitoRule mockitoJUnit = MockitoJUnit.rule();
+    @Rule
+    public MockitoRule mockitoJUnit = MockitoJUnit.rule();
 
-	private TestScheduler scheduler;
+    private TestScheduler scheduler;
 
-	@Mock
-	private Game game;
+    @Mock
+    private Game game;
 
-	private List<SocketPlayer> players = new ArrayList<>();
+    private List<SocketPlayer> players = new ArrayList<>();
 
-	@Before
-	public void before() {
-		scheduler = new TestScheduler();
-		RxJavaHooks.setOnComputationScheduler(d -> scheduler);
-	}
+    @Before
+    public void before() {
+        scheduler = new TestScheduler();
+        RxJavaHooks.setOnComputationScheduler(d -> scheduler);
+    }
 
-	@Test
-	public void testRound_CommandsMove() throws Exception {
-		ServerWebSocket socket1 = Mockito.mock(ServerWebSocket.class);
-		players.add(new SocketPlayer("player1", socket1));
-		Commands commands = new Commands(singletonList(new Move(1, Direction.EAST)));
-		Observable<SocketMessage> mq = Observable.just(new SocketMessage(socket1, commands));
-		GameSession session = new GameSession(game, players, 5);
+    @Test
+    public void testRound_CommandsMove() throws Exception {
+        ServerWebSocket socket1 = Mockito.mock(ServerWebSocket.class);
+        players.add(new SocketPlayer("player1", socket1));
+        Commands commands = new Commands(singletonList(new Move(1, Direction.EAST)));
+        Observable<SocketMessage> mq = Observable.just(new SocketMessage(socket1, commands));
+        GameSession session = new GameSession(game, players, 5);
 
-		session.round(0, mq);
+        session.round(0, mq);
 
-		verify(game).execute(
-			singletonList(new MoveCommand(new Player("player1"), 1, com.github.ocelotwars.engine.Direction.EAST))
-		);
-	}
+        verify(game).execute(
+            singletonList(new MoveCommand(new Player("player1"), 1, com.github.ocelotwars.engine.Direction.EAST)));
+    }
 
-	@Test
-	public void testRound_CommandsGather() throws Exception {
-		ServerWebSocket socket1 = Mockito.mock(ServerWebSocket.class);
-		players.add(new SocketPlayer("player1", socket1));
-		Commands commands = new Commands(singletonList(new Gather(1)));
-		Observable<SocketMessage> mq = Observable.just(new SocketMessage(socket1, commands));
-		GameSession session = new GameSession(game, players, 5);
+    @Test
+    public void testRound_CommandsGather() throws Exception {
+        ServerWebSocket socket1 = Mockito.mock(ServerWebSocket.class);
+        players.add(new SocketPlayer("player1", socket1));
+        Commands commands = new Commands(singletonList(new Gather(1)));
+        Observable<SocketMessage> mq = Observable.just(new SocketMessage(socket1, commands));
+        GameSession session = new GameSession(game, players, 5);
 
-		session.round(0, mq);
+        session.round(0, mq);
 
-		verify(game).execute(singletonList(new GatherCommand(new Player("player1"), 1)));
-	}
+        verify(game).execute(singletonList(new GatherCommand(new Player("player1"), 1)));
+    }
 
-	@Test
-	public void testRound_TwoPlayers_CommandsForPlayer1() throws Exception {
-		ServerWebSocket socket1 = Mockito.mock(ServerWebSocket.class);
-		ServerWebSocket socket2 = Mockito.mock(ServerWebSocket.class);
-		players.add(new SocketPlayer("player1", socket1));
-		players.add(new SocketPlayer("player2", socket2));
-		Commands commands = new Commands(singletonList(new Gather(1)));
-		Observable<SocketMessage> mq = Observable.just(new SocketMessage(socket1, commands));
-		GameSession session = new GameSession(game, players, 5);
+    @Test
+    public void testRound_TwoPlayers_CommandsForPlayer1() throws Exception {
+        ServerWebSocket socket1 = Mockito.mock(ServerWebSocket.class);
+        ServerWebSocket socket2 = Mockito.mock(ServerWebSocket.class);
+        players.add(new SocketPlayer("player1", socket1));
+        players.add(new SocketPlayer("player2", socket2));
+        Commands commands = new Commands(singletonList(new Gather(1)));
+        Observable<SocketMessage> mq = Observable.just(new SocketMessage(socket1, commands));
+        GameSession session = new GameSession(game, players, 5);
 
-		session.round(0, mq);
+        session.round(0, mq);
 
-		verify(game).execute(singletonList(new GatherCommand(new Player("player1"), 1)));
-	}
+        verify(game).execute(singletonList(new GatherCommand(new Player("player1"), 1)));
+    }
 
-	@Test
-	public void testRound_TwoPlayers_CommandsForPlayer2() throws Exception {
-		ServerWebSocket socket1 = Mockito.mock(ServerWebSocket.class);
-		ServerWebSocket socket2 = Mockito.mock(ServerWebSocket.class);
-		players.add(new SocketPlayer("player1", socket1));
-		players.add(new SocketPlayer("player2", socket2));
-		Commands commands = new Commands(singletonList(new Gather(1)));
-		Observable<SocketMessage> mq = Observable.just(new SocketMessage(socket2, commands));
-		GameSession session = new GameSession(game, players, 5);
+    @Test
+    public void testRound_TwoPlayers_CommandsForPlayer2() throws Exception {
+        ServerWebSocket socket1 = Mockito.mock(ServerWebSocket.class);
+        ServerWebSocket socket2 = Mockito.mock(ServerWebSocket.class);
+        players.add(new SocketPlayer("player1", socket1));
+        players.add(new SocketPlayer("player2", socket2));
+        Commands commands = new Commands(singletonList(new Gather(1)));
+        Observable<SocketMessage> mq = Observable.just(new SocketMessage(socket2, commands));
+        GameSession session = new GameSession(game, players, 5);
 
-		session.round(0, mq);
+        session.round(0, mq);
 
-		verify(game).execute(singletonList(new GatherCommand(new Player("player2"), 1)));
-	}
+        verify(game).execute(singletonList(new GatherCommand(new Player("player2"), 1)));
+    }
 
-	@Test
-	public void testRound_TwoPlayers_CommandsForPlayer12() throws Exception {
-		ServerWebSocket socket1 = Mockito.mock(ServerWebSocket.class);
-		ServerWebSocket socket2 = Mockito.mock(ServerWebSocket.class);
-		players.add(new SocketPlayer("player1", socket1));
-		players.add(new SocketPlayer("player2", socket2));
-		Commands commands1 = new Commands(singletonList(new Move(1, Direction.NORTH)));
-		Commands commands2 = new Commands(singletonList(new Gather(1)));
-		Observable<SocketMessage> mq = Observable.just(new SocketMessage(socket2, commands2), new SocketMessage(socket1, commands1));
-		GameSession session = new GameSession(game, players, 5);
+    @Test
+    public void testRound_TwoPlayers_CommandsForPlayer12() throws Exception {
+        ServerWebSocket socket1 = Mockito.mock(ServerWebSocket.class);
+        ServerWebSocket socket2 = Mockito.mock(ServerWebSocket.class);
+        players.add(new SocketPlayer("player1", socket1));
+        players.add(new SocketPlayer("player2", socket2));
+        Commands commands1 = new Commands(singletonList(new Move(1, Direction.NORTH)));
+        Commands commands2 = new Commands(singletonList(new Gather(1)));
+        Observable<SocketMessage> mq = Observable.just(new SocketMessage(socket2, commands2), new SocketMessage(socket1, commands1));
+        GameSession session = new GameSession(game, players, 5);
 
-		session.round(0, mq);
+        session.round(0, mq);
 
-		verify(game).execute(singletonList(new MoveCommand(new Player("player1"), 1, com.github.ocelotwars.engine.Direction.NORTH)));
-		verify(game).execute(singletonList(new GatherCommand(new Player("player2"), 1)));
-	}
+        verify(game).execute(singletonList(new MoveCommand(new Player("player1"), 1, com.github.ocelotwars.engine.Direction.NORTH)));
+        verify(game).execute(singletonList(new GatherCommand(new Player("player2"), 1)));
+    }
 
-	@Test
-	public void testRound_TwoPlayers_CommandsForIllegalSecondMessage_() throws Exception {
-		ServerWebSocket socket1 = Mockito.mock(ServerWebSocket.class);
-		ServerWebSocket socket2 = Mockito.mock(ServerWebSocket.class);
-		players.add(new SocketPlayer("player1", socket1));
-		players.add(new SocketPlayer("player2", socket2));
-		Commands commands1 = new Commands(singletonList(new Move(1, Direction.NORTH)));
-		Commands commands2 = new Commands(singletonList(new Gather(1)));
-		Commands commands3 = new Commands(singletonList(new Unload(1)));
-		Observable<SocketMessage> mq = Observable.just(
-			new SocketMessage(socket2, commands2),
-			new SocketMessage(socket1, commands1),
-			new SocketMessage(socket2, commands3));
-		GameSession session = new GameSession(game, players, 5);
+    @Test
+    public void testRound_TwoPlayers_CommandsForIllegalSecondMessage_() throws Exception {
+        ServerWebSocket socket1 = Mockito.mock(ServerWebSocket.class);
+        ServerWebSocket socket2 = Mockito.mock(ServerWebSocket.class);
+        players.add(new SocketPlayer("player1", socket1));
+        players.add(new SocketPlayer("player2", socket2));
+        Commands commands1 = new Commands(singletonList(new Move(1, Direction.NORTH)));
+        Commands commands2 = new Commands(singletonList(new Gather(1)));
+        Commands commands3 = new Commands(singletonList(new Unload(1)));
+        Observable<SocketMessage> mq = Observable.just(
+            new SocketMessage(socket2, commands2),
+            new SocketMessage(socket1, commands1),
+            new SocketMessage(socket2, commands3));
+        GameSession session = new GameSession(game, players, 5);
 
-		session.round(0, mq);
+        session.round(0, mq);
 
-		verify(game).execute(singletonList(new MoveCommand(new Player("player1"), 1, com.github.ocelotwars.engine.Direction.NORTH)));
-		verify(game).execute(singletonList(new GatherCommand(new Player("player2"), 1)));
-	}
+        verify(game).execute(singletonList(new MoveCommand(new Player("player1"), 1, com.github.ocelotwars.engine.Direction.NORTH)));
+        verify(game).execute(singletonList(new GatherCommand(new Player("player2"), 1)));
+    }
 
-	@Test
-	public void testRound_TwoPlayers_CommandsWithTimeout() throws Exception {
-		ServerWebSocket socket1 = Mockito.mock(ServerWebSocket.class);
-		ServerWebSocket socket2 = Mockito.mock(ServerWebSocket.class);
-		players.add(new SocketPlayer("player1", socket1));
-		players.add(new SocketPlayer("player2", socket2));
-		Commands commands1 = new Commands(singletonList(new Move(1, Direction.NORTH)));
-		Commands commands2 = new Commands(singletonList(new Gather(1)));
+    @Test
+    public void testRound_TwoPlayers_CommandsWithTimeout() throws Exception {
+        ServerWebSocket socket1 = Mockito.mock(ServerWebSocket.class);
+        ServerWebSocket socket2 = Mockito.mock(ServerWebSocket.class);
+        players.add(new SocketPlayer("player1", socket1));
+        players.add(new SocketPlayer("player2", socket2));
+        Commands commands1 = new Commands(singletonList(new Move(1, Direction.NORTH)));
+        Commands commands2 = new Commands(singletonList(new Gather(1)));
 
-		Observable<SocketMessage> mq = Observable.just(new SocketMessage(socket1, commands1), new SocketMessage(socket2, commands2))
-			.zipWith(Observable.interval(3, TimeUnit.SECONDS), (message, time) -> message);
-		GameSession session = new GameSession(game, players, 5);
+        Observable<SocketMessage> mq = Observable.just(new SocketMessage(socket1, commands1), new SocketMessage(socket2, commands2))
+            .zipWith(Observable.interval(3, TimeUnit.SECONDS), (message, time) -> message);
+        GameSession session = new GameSession(game, players, 5);
 
-		session.round(0, mq);
-		scheduler.advanceTimeBy(6, TimeUnit.SECONDS);
+        session.round(0, mq);
+        scheduler.advanceTimeBy(6, TimeUnit.SECONDS);
 
-		verify(game).execute(singletonList(new MoveCommand(new Player("player1"), 1, com.github.ocelotwars.engine.Direction.NORTH)));
-	}
+        verify(game).execute(singletonList(new MoveCommand(new Player("player1"), 1, com.github.ocelotwars.engine.Direction.NORTH)));
+    }
 
-	@Test
-	public void testRound_notifysAllPlayers() throws Exception {
-		ServerWebSocket socket1 = Mockito.mock(ServerWebSocket.class);
-		ServerWebSocket socket2 = Mockito.mock(ServerWebSocket.class);
-		players.add(new SocketPlayer("player1", socket1));
-		players.add(new SocketPlayer("player2", socket2));
-		Observable<SocketMessage> mq = Observable.empty();
-		GameSession session = new GameSession(game, players, 5);
+    @Test
+    public void testRound_notifysAllPlayers() throws Exception {
+        ServerWebSocket socket1 = Mockito.mock(ServerWebSocket.class);
+        ServerWebSocket socket2 = Mockito.mock(ServerWebSocket.class);
+        players.add(new SocketPlayer("player1", socket1));
+        players.add(new SocketPlayer("player2", socket2));
+        Observable<SocketMessage> mq = Observable.empty();
+        GameSession session = new GameSession(game, players, 5);
 
-		session.round(0, mq);
+        session.round(0, mq);
 
-		verify(socket1).writeFinalTextFrame("{\"@type\":\"Notify\"}");
-		verify(socket2).writeFinalTextFrame("{\"@type\":\"Notify\"}");
-	}
+        verify(socket1).writeFinalTextFrame("{\"@type\":\"Notify\"}");
+        verify(socket2).writeFinalTextFrame("{\"@type\":\"Notify\"}");
+    }
 
-	@Test
-	public void testRounds_2rounds_runInSequence() throws Exception {
-		ServerWebSocket socket1 = Mockito.mock(ServerWebSocket.class);
-		ServerWebSocket socket2 = Mockito.mock(ServerWebSocket.class);
-		players.add(new SocketPlayer("player1", socket1));
-		players.add(new SocketPlayer("player2", socket2));
-		Commands commands1 = new Commands(singletonList(new Move(1, Direction.NORTH)));
-		Commands commands2 = new Commands(singletonList(new Move(1, Direction.WEST)));
+    @Test
+    public void testRounds_2rounds_runInSequence() throws Exception {
+        ServerWebSocket socket1 = Mockito.mock(ServerWebSocket.class);
+        ServerWebSocket socket2 = Mockito.mock(ServerWebSocket.class);
+        players.add(new SocketPlayer("player1", socket1));
+        players.add(new SocketPlayer("player2", socket2));
+        Commands commands1 = new Commands(singletonList(new Move(1, Direction.NORTH)));
+        Commands commands2 = new Commands(singletonList(new Move(1, Direction.WEST)));
 
-		PublishSubject<SocketMessage> mq = PublishSubject.create();
+        PublishSubject<SocketMessage> mq = PublishSubject.create();
 
-		GameSession session = new GameSession(game, players, 5);
+        GameSession session = new GameSession(game, players, 5);
 
-		session.rounds(2, mq);
+        session.rounds(2, mq);
 
-		scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
-		verify(socket1).writeFinalTextFrame("{\"@type\":\"Notify\"}");
-		verify(socket2).writeFinalTextFrame("{\"@type\":\"Notify\"}");
-		scheduler.advanceTimeBy(2, TimeUnit.SECONDS);
-		mq.onNext(new SocketMessage(socket1, commands1));
+        scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
+        verify(socket1).writeFinalTextFrame("{\"@type\":\"Notify\"}");
+        verify(socket2).writeFinalTextFrame("{\"@type\":\"Notify\"}");
+        scheduler.advanceTimeBy(2, TimeUnit.SECONDS);
+        mq.onNext(new SocketMessage(socket1, commands1));
 
-		verify(game, times(1)).execute(
-		    singletonList(new MoveCommand(new Player("player1"), 1, com.github.ocelotwars.engine.Direction.NORTH))
-        );
+        verify(game, times(1)).execute(
+            singletonList(new MoveCommand(new Player("player1"), 1, com.github.ocelotwars.engine.Direction.NORTH)));
 
-		Mockito.reset(game, socket1, socket2);
+        Mockito.reset(game, socket1, socket2);
 
-		scheduler.advanceTimeBy(3, TimeUnit.SECONDS);
-		verify(socket1).writeFinalTextFrame("{\"@type\":\"Notify\"}");
-		verify(socket2).writeFinalTextFrame("{\"@type\":\"Notify\"}");
-		mq.onNext(new SocketMessage(socket2, commands2));
+        scheduler.advanceTimeBy(3, TimeUnit.SECONDS);
+        verify(socket1).writeFinalTextFrame("{\"@type\":\"Notify\"}");
+        verify(socket2).writeFinalTextFrame("{\"@type\":\"Notify\"}");
+        mq.onNext(new SocketMessage(socket2, commands2));
 
-		verify(game, times(1)).execute(
-		    singletonList(new MoveCommand(new Player("player2"), 1, com.github.ocelotwars.engine.Direction.WEST)));
-	}
+        verify(game, times(1)).execute(
+            singletonList(new MoveCommand(new Player("player2"), 1, com.github.ocelotwars.engine.Direction.WEST)));
+    }
 
-	@Test
-	public void testRounds_2rounds_terminatesWithWinner() throws Exception {
-		ServerWebSocket socket1 = Mockito.mock(ServerWebSocket.class);
-		ServerWebSocket socket2 = Mockito.mock(ServerWebSocket.class);
-		players.add(new SocketPlayer("player1", socket1));
-		players.add(new SocketPlayer("player2", socket2));
-		Commands commands1 = new Commands(singletonList(new Move(1, Direction.NORTH)));
-		Commands commands2 = new Commands(singletonList(new Move(1, Direction.WEST)));
+    @Test
+    public void testRounds_2rounds_terminatesWithWinner() throws Exception {
+        ServerWebSocket socket1 = Mockito.mock(ServerWebSocket.class);
+        ServerWebSocket socket2 = Mockito.mock(ServerWebSocket.class);
+        players.add(new SocketPlayer("player1", socket1));
+        players.add(new SocketPlayer("player2", socket2));
+        Commands commands1 = new Commands(singletonList(new Move(1, Direction.NORTH)));
+        Commands commands2 = new Commands(singletonList(new Move(1, Direction.WEST)));
 
-		PublishSubject<SocketMessage> mq = PublishSubject.create();
+        PublishSubject<SocketMessage> mq = PublishSubject.create();
 
-		GameSession session = new GameSession(game, players, 5);
-		SocketPlayer[] winner = new SocketPlayer[1];
-		session.winner().subscribe(p -> {winner[0] = p;});
+        GameSession session = new GameSession(game, players, 5);
+        SocketPlayer[] winner = new SocketPlayer[1];
+        session.winner().subscribe(p -> {
+            winner[0] = p;
+        });
 
-		session.rounds(2, mq);
+        session.rounds(2, mq);
 
-		scheduler.advanceTimeBy(3, TimeUnit.SECONDS);
-		mq.onNext(new SocketMessage(socket1, commands1));
-		scheduler.advanceTimeBy(3, TimeUnit.SECONDS);
-		mq.onNext(new SocketMessage(socket2, commands2));
+        scheduler.advanceTimeBy(3, TimeUnit.SECONDS);
+        mq.onNext(new SocketMessage(socket1, commands1));
+        scheduler.advanceTimeBy(3, TimeUnit.SECONDS);
+        mq.onNext(new SocketMessage(socket2, commands2));
 
-		verify(game).execute(singletonList(new MoveCommand(new Player("player1"), 1, com.github.ocelotwars.engine.Direction.NORTH)));
-		verify(game).execute(singletonList(new MoveCommand(new Player("player2"), 1, com.github.ocelotwars.engine.Direction.WEST)));
+        verify(game).execute(singletonList(new MoveCommand(new Player("player1"), 1, com.github.ocelotwars.engine.Direction.NORTH)));
+        verify(game).execute(singletonList(new MoveCommand(new Player("player2"), 1, com.github.ocelotwars.engine.Direction.WEST)));
 
-		assertThat(winner[0], nullValue());
+        assertThat(winner[0], nullValue());
 
-		scheduler.advanceTimeBy(4, TimeUnit.SECONDS);
+        scheduler.advanceTimeBy(4, TimeUnit.SECONDS);
 
-		assertThat(winner[0], notNullValue());
-	}
+        assertThat(winner[0], notNullValue());
+    }
 
 }

--- a/src/test/java/com/github/ocelotwars/service/HostTest.java
+++ b/src/test/java/com/github/ocelotwars/service/HostTest.java
@@ -7,10 +7,10 @@ import org.junit.Test;
 
 public class HostTest {
 
-	@Test
-	public void testMapMessage() throws Exception {
-		Message register = new Host().mapMessage("{\"@type\":\"register\"}");
-		assertThat(register, instanceOf(Register.class));
-	}
+    @Test
+    public void testMapMessage() throws Exception {
+        Message register = new Host().mapMessage("{\"@type\":\"register\"}");
+        assertThat(register, instanceOf(Register.class));
+    }
 
 }


### PR DESCRIPTION
This pull request adds the [Spotless gradle plugin](https://github.com/diffplug/spotless/tree/master/plugin-gradle) to our build: It checks the code formatting based in the exported Eclipse format settings in `ocelot-wars-code-conventions.xml`. The checks is performed in the `check` task that is already run so we don't need to change your Travis config file.

We could also check the order of imports. I didn't include this in this pull request. The import order settings could also be exported from Eclipse like the code conventions.